### PR TITLE
New NUOPC CMEPS development branch from cime5.6.0

### DIFF
--- a/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
@@ -102,7 +102,8 @@
       @
       </value>
       <value COMP_OCN="socn">
-  	  @atm_cpl_dt
+      @ocn_cpl_dt   #ocean coupling step
+  	  @atm_cpl_dt  # atmosphere coupling step
             MED med_phases_prep_ice
             MED med_connectors_prep_med2ice
             MED -> ICE :remapMethod=redist
@@ -141,9 +142,11 @@
             ATM -> MED :remapMethod=redist
             MED med_connectors_post_atm2med
 	  @
+       @
       </value>
       <value COMP_ATM="cam" COMP_OCN="docn" COMP_WAV="swav">
-  	  @atm_cpl_dt
+      @ocn_cpl_dt   #ocean coupling step
+  	  @atm_cpl_dt # atmosphere coupling step
             MED med_phases_accum_fast
 	    MED med_phases_prep_ocn
             MED med_connectors_prep_med2ocn
@@ -173,6 +176,7 @@
 	    ATM -> MED :remapMethod=redist
 	    MED med_connectors_post_atm2med
 	  @
+       @
       </value>
     </values>
   </entry>


### PR DESCRIPTION
This rebases the head of the nuopcB to cime5.6.0.

- To  get the prognostic components that are compatible with this nuopc-cmeps working, you will need to do the following:

```
> git clone https://github.com/ESCOMP/UFSCOMP.git
> cd UFSCOMP
> git checkout nuopc-cmeps-v0.1
> ./manage_externals/checkout_externals -o
```

- Once the sandbox is created with the above prognostic components, the following tests can be run out of the box if the prognostic components are added to the sandbox via:

```
SMS_Vnuopc.f19_g16.X.cheyenne_intel
SMS_Vnuopc_Ld1.T31_g37_rx1.A.cheyenne_intel
SMS_Vnuopc_Ld2.ww3a.ADWAV.cheyenne_intel
SMS_Vnuopc_Ln5.T62_g37.DTEST.cheyenne_intel.cice-nuopc_cap
SMS_Vnuopc_Ln5.f45_f45_mg37.F2000Nuopc.cheyenne_intel.cam-nuopc_cap
SMS_Vnuopc_Ln5.f45_f45_mg37.I2000Clm50SpNuopc.cheyenne_intel.clm-nuopc_cap
SMS_Vnuopc_Ln5.ne16_ne16_mg17.QPC4.cheyenne_intel.cam-nuopc_cap
SMS_Vmct.f19_g16.X.cheyenne_intel
SMS_Vmct_Ld1.T31_g37_rx1.A.cheyenne_intel
SMS_Vmct_Ld2.ww3a.ADWAV.cheyenne_intel
SMS_Vmct_Ln5.T62_g37.DTEST.cheyenne_intel.cice-nuopc_cap
SMS_Vmct_Ln5.f45_f45_mg37.F2000Nuopc.cheyenne_intel.cam-nuopc_cap
SMS_Vmct_Ln5.f45_f45_mg37.I2000Clm50SpNuopc.cheyenne_intel.clm-nuopc_cap
SMS_Vmct_Ln5.ne16_ne16_mg17.QPC4.cheyenne_intel.cam-nuopc_cap
```

- **Note:** the pelayout for the test `SMS_Vnuopc_Ln5.f45_f45_mg37.I2000Clm50SpNuopc.cheyenne_intel.clm-nuopc_cap`
needs to be modified before the test is run - since currently there is a problem for a layout where the atm pes are less than the mediator pes. This can be done via the following commands:

```
> ./xmlchange NTASKS=36
> ./xmlchange ROOTPE=0
> ./case.setup --reset
> ./case.build
> ./case.submit
```
- If a file, testlist.txt, is created in cime/scripts with the above
lists of tests - then they can be run as a suite with the following
command on cheyenne (this will place the tests

`qcmd -- ./create_test --testfile ./testlist.txt --test-id your_test_id &`

- This PR will also be tagged as noupc-cmeps-v0.1

Test suite: (see above)
Test baseline: (compared mct and nuopc versions)
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes:none
User interface changes?:
Update gh-pages html (Y/N)?:N
Code review:

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]
User interface changes?: 
Update gh-pages html (Y/N)?:
Code review: 
