### PR TITLE
add mediator restart capability and update clocks/alarms/filenames

### DIFF
--- a/src/components/data_comps/datm/datm_comp_mod.F90
+++ b/src/components/data_comps/datm/datm_comp_mod.F90
@@ -12,7 +12,7 @@ module datm_comp_mod
   use shr_sys_mod
   use shr_kind_mod   , only: IN=>SHR_KIND_IN, R8=>SHR_KIND_R8, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL
   use shr_file_mod   , only: shr_file_getunit, shr_file_freeunit
-  use shr_cal_mod    , only: shr_cal_date2julian, shr_cal_ymdtod2string
+  use shr_cal_mod    , only: shr_cal_date2julian, shr_cal_datetod2string
   use shr_mpi_mod    , only: shr_mpi_bcast
   use shr_precip_mod , only: shr_precip_partition_rain_snow_ramp
   use shr_strdata_mod, only: shr_strdata_type, shr_strdata_pioinit, shr_strdata_init
@@ -250,7 +250,7 @@ CONTAINS
     integer(IN)   :: kfld        ! fld index
     integer(IN)   :: cnt         ! counter
     integer(IN)   :: idt         ! integer timestep
-    logical       :: exists      ! filename existance
+    logical       :: exists,exists1      ! filename existance
     integer(IN)   :: nu          ! unit number
     integer(IN)   :: CurrentYMD  ! model date
     integer(IN)   :: CurrentTOD  ! model sec into model date
@@ -488,23 +488,24 @@ CONTAINS
     !----------------------------------------------------------------------------
 
     if (read_restart) then
+       exists = .false.
+       exists1 = .false.
        if (trim(rest_file)      == trim(nullstr) .and. &
-            trim(rest_file_strm) == trim(nullstr)) then
+           trim(rest_file_strm) == trim(nullstr)) then
           if (my_task == master_task) then
-             write(logunit,F00) ' restart filenames from rpointer'
+             write(logunit,F00) ' restart filenames from rpointer = ',trim(rpfile)
              call shr_sys_flush(logunit)
              inquire(file=trim(rpfile)//trim(inst_suffix),exist=exists)
-             if (.not.exists) then
-                write(logunit,F00) ' ERROR: rpointer file does not exist'
-                call shr_sys_abort(trim(subname)//' ERROR: rpointer file missing')
+             if (exists) then
+                nu = shr_file_getUnit()
+                open(nu,file=trim(rpfile)//trim(inst_suffix),form='formatted')
+                read(nu,'(a)') rest_file
+                read(nu,'(a)') rest_file_strm
+                close(nu)
+                call shr_file_freeUnit(nu)
+                inquire(file=trim(rest_file_strm),exist=exists)
+                inquire(file=trim(rest_file),exist=exists1)
              endif
-             nu = shr_file_getUnit()
-             open(nu,file=trim(rpfile)//trim(inst_suffix),form='formatted')
-             read(nu,'(a)') rest_file
-             read(nu,'(a)') rest_file_strm
-             close(nu)
-             call shr_file_freeUnit(nu)
-             inquire(file=trim(rest_file_strm),exist=exists)
           endif
           call shr_mpi_bcast(rest_file,mpicom,'rest_file')
           call shr_mpi_bcast(rest_file_strm,mpicom,'rest_file_strm')
@@ -518,6 +519,15 @@ CONTAINS
        endif
 
        call shr_mpi_bcast(exists,mpicom,'exists')
+       call shr_mpi_bcast(exists1,mpicom,'exists1')
+
+!       if (exists1) then
+!          if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file)
+!          call shr_pcdf_readwrite('read',SDATM%pio_subsystem, SDATM%io_type, &
+!               trim(rest_file),mpicom,gsmap=gsmap,rf1=water,rf1n='water',io_format=SDATM%io_format)
+!       else
+!          if (my_task == master_task) write(logunit,F00) ' file not found, skipping ',trim(rest_file)
+!       endif
 
        if (exists) then
           if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file_strm)
@@ -565,7 +575,7 @@ CONTAINS
   subroutine datm_comp_run(EClock, x2a, a2x, &
        SDATM, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, nextsw_cday, write_restart, &
-       currentYMD, currentTOD, case_name)
+       target_ymd, target_tod, case_name)
 
     ! !DESCRIPTION: run method for datm model
 
@@ -586,8 +596,8 @@ CONTAINS
     integer(IN)            , intent(in)    :: logunit          ! logging unit number
     real(R8)               , intent(out)   :: nextsw_cday      ! calendar of next atm sw
     logical                , intent(in)    :: write_restart    ! restart alarm is on
-    integer(IN)            , intent(in)    :: currentYMD       ! model date
-    integer(IN)            , intent(in)    :: currentTOD       ! model sec into model date
+    integer(IN)            , intent(in)    :: target_ymd       ! model date
+    integer(IN)            , intent(in)    :: target_tod       ! model sec into model date
     character(CL)          , intent(in), optional :: case_name ! case name
 
     !--- local ---
@@ -635,12 +645,12 @@ CONTAINS
     call t_startf('datm')
 
     call seq_timemgr_EClockGetData( EClock, calendar=calendar, stepno=stepno)
-    nextsw_cday = datm_shr_getNextRadCDay( CurrentYMD, CurrentTOD, stepno, idt, iradsw, calendar )
+    nextsw_cday = datm_shr_getNextRadCDay( target_ymd, target_tod, stepno, idt, iradsw, calendar )
 
     !--- copy all fields from streams to a2x as default ---
 
     call t_startf('datm_strdata_advance')
-    call shr_strdata_advance(SDATM,currentYMD,currentTOD,mpicom,'datm')
+    call shr_strdata_advance(SDATM,target_ymd,target_tod,mpicom,'datm')
     call t_stopf('datm_strdata_advance')
 
     call t_barrierf('datm_scatter_BARRIER',mpicom)
@@ -701,7 +711,7 @@ CONTAINS
           call datm_shr_CORE2getFactors(factorFn,windFactor,winddFactor,qsatFactor, &
                mpicom,compid,gsmap,ggrid,SDATM%nxg,SDATM%nyg)
        endif
-       call shr_cal_date2julian(currentYMD,currentTOD,rday,calendar)
+       call shr_cal_date2julian(target_ymd,target_tod,rday,calendar)
        rday = mod((rday - 1.0_R8),365.0_R8)
        cosfactor = cos((2.0_R8*SHR_CONST_PI*rday)/365 - phs_c0)
 
@@ -824,7 +834,7 @@ CONTAINS
                  mpicom,compid,gsmap,ggrid,SDATM%nxg,SDATM%nyg)
           endif
        endif
-       call shr_cal_date2julian(currentYMD,currentTOD,rday,calendar)
+       call shr_cal_date2julian(target_ymd,target_tod,rday,calendar)
        rday = mod((rday - 1.0_R8),365.0_R8)
        cosfactor = cos((2.0_R8*SHR_CONST_PI*rday)/365 - phs_c0)
 
@@ -1102,26 +1112,26 @@ CONTAINS
 
     if (dbug > 1 .and. my_task == master_task) then
        do n = 1,lsize
-          write(logunit,F01)'export: ymd,tod,n,Sa_z       = ',currentYMD, currentTOD, n,a2x%rAttr(kz,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_topo    = ',currentYMD, currentTOD, n,a2x%rAttr(ktopo,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_u       = ',currentYMD, currentTOD, n,a2x%rAttr(ku,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_v       = ',currentYMD, currentTOD, n,a2x%rAttr(kv,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_tbot    = ',currentYMD, currentTOD, n,a2x%rAttr(ktbot,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_ptem    = ',currentYMD, currentTOD, n,a2x%rAttr(kptem,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_shum    = ',currentYMD, currentTOD, n,a2x%rAttr(kshum,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_dens    = ',currentYMD, currentTOD, n,a2x%rAttr(kdens,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_pbot    = ',currentYMD, currentTOD, n,a2x%rAttr(kpbot,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_pslv    = ',currentYMD, currentTOD, n,a2x%rAttr(kpslv,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_lwdn    = ',currentYMD, currentTOD, n,a2x%rAttr(klwdn,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_rainc = ',currentYMD, currentTOD, n,a2x%rAttr(krc,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_rainl = ',currentYMD, currentTOD, n,a2x%rAttr(krl,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_snowc = ',currentYMD, currentTOD, n,a2x%rAttr(ksc,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_snowl = ',currentYMD, currentTOD, n,a2x%rAttr(ksl,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_swndr = ',currentYMD, currentTOD, n,a2x%rAttr(kswndr,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_swndf = ',currentYMD, currentTOD, n,a2x%rAttr(kswndf,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_swvdr = ',currentYMD, currentTOD, n,a2x%rAttr(kswvdr,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_swvdf = ',currentYMD, currentTOD, n,a2x%rAttr(kswvdf,n)
-          write(logunit,F01)'export: ymd,tod,n,Faxa_swnet = ',currentYMD, currentTOD, n,a2x%rAttr(kswnet,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_z       = ',target_ymd, target_tod, n,a2x%rAttr(kz,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_topo    = ',target_ymd, target_tod, n,a2x%rAttr(ktopo,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_u       = ',target_ymd, target_tod, n,a2x%rAttr(ku,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_v       = ',target_ymd, target_tod, n,a2x%rAttr(kv,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_tbot    = ',target_ymd, target_tod, n,a2x%rAttr(ktbot,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_ptem    = ',target_ymd, target_tod, n,a2x%rAttr(kptem,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_shum    = ',target_ymd, target_tod, n,a2x%rAttr(kshum,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_dens    = ',target_ymd, target_tod, n,a2x%rAttr(kdens,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_pbot    = ',target_ymd, target_tod, n,a2x%rAttr(kpbot,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_pslv    = ',target_ymd, target_tod, n,a2x%rAttr(kpslv,n)
+          write(logunit,F01)'export: ymd,tod,n,Sa_lwdn    = ',target_ymd, target_tod, n,a2x%rAttr(klwdn,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_rainc = ',target_ymd, target_tod, n,a2x%rAttr(krc,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_rainl = ',target_ymd, target_tod, n,a2x%rAttr(krl,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_snowc = ',target_ymd, target_tod, n,a2x%rAttr(ksc,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_snowl = ',target_ymd, target_tod, n,a2x%rAttr(ksl,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_swndr = ',target_ymd, target_tod, n,a2x%rAttr(kswndr,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_swndf = ',target_ymd, target_tod, n,a2x%rAttr(kswndf,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_swvdr = ',target_ymd, target_tod, n,a2x%rAttr(kswvdr,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_swvdf = ',target_ymd, target_tod, n,a2x%rAttr(kswvdf,n)
+          write(logunit,F01)'export: ymd,tod,n,Faxa_swnet = ',target_ymd, target_tod, n,a2x%rAttr(kswnet,n)
        end do
     end if
 
@@ -1131,8 +1141,7 @@ CONTAINS
 
     if (write_restart) then
        call t_startf('datm_restart')
-       call seq_timemgr_EClockGetData( EClock, curr_yr=yy, curr_mon=mm, curr_day=dd, curr_tod=tod)
-       call shr_cal_ymdtod2string(date_str, yy,mm,dd,currentTOD)
+       call shr_cal_datetod2string(date_str, target_ymd, target_tod)
 
        write(rest_file,"(6a)") &
             trim(case_name), '.datm',trim(inst_suffix),'.r.', trim(date_str), '.nc'
@@ -1147,7 +1156,7 @@ CONTAINS
           call shr_file_freeUnit(nu)
        endif
 
-       if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file_strm),currentYMD,currentTOD
+       if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file_strm),target_ymd,target_tod
        call shr_strdata_restWrite(trim(rest_file_strm),SDATM,mpicom,trim(case_name),'SDATM strdata')
        call shr_sys_flush(logunit)
        call t_stopf('datm_restart')
@@ -1162,7 +1171,7 @@ CONTAINS
 
     call t_startf('datm_run2')
     if (my_task == master_task) then
-       write(logunit,F04) trim(myModelName),': model date ', CurrentYMD,CurrentTOD
+       write(logunit,F04) trim(myModelName),': model date ', target_ymd,target_tod
        call shr_sys_flush(logunit)
     end if
 

--- a/src/components/data_comps/datm/nuopc/datm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/datm_comp_nuopc.F90
@@ -10,7 +10,9 @@ module datm_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet
+  use seq_timemgr_mod       , only : seq_timemgr_EClockPrint
+  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet, seq_timemgr_alarmSetOff
+  use seq_timemgr_mod       , only : seq_timemgr_alarm_restart, seq_timemgr_alarmIsOn
   use esmFlds               , only : fldListFr, fldListTo, compatm, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
@@ -83,6 +85,7 @@ module datm_comp_nuopc
   logical                    :: atm_prognostic            ! flag
   logical                    :: unpack_import
   character(CL)              :: case_name                 ! case name
+  character(CL)              :: tmpstr                    ! tmp string
   integer                    :: dbrc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
@@ -566,6 +569,8 @@ module datm_comp_nuopc
     logical                  :: write_restart ! restart alarm is ringing
     integer(IN)              :: currentYMD    ! model date
     integer(IN)              :: currentTOD    ! model sec into model date
+    integer(IN)              :: nextYMD       ! model date
+    integer(IN)              :: nextTOD       ! model sec into model date
     type(ESMF_Time)          :: currTime, nextTime
     type(ESMF_TimeInterval)  :: timeStep
     character(len=*),parameter  :: subname=trim(modName)//':(ModelAdvance) '
@@ -610,31 +615,24 @@ module datm_comp_nuopc
     ! Run model
     !--------------------------------
 
-    call ESMF_ClockGetAlarm(clock, alarmname='seq_timemgr_alarm_restart', alarm=alarm, rc=rc)
+    write_restart = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    ! Determine if its time to write a restart file
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-       write_restart = .true.
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_AlarmRingerOff( alarm, rc=rc )
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       write_restart = .false.
-    endif
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! For nuopc - the component clock is advanced at the end of the time interval
     ! For these to match for now - need to advance nuopc one timestep ahead for
     ! shr_strdata time interpolation
-    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep)
+    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     nextTime = currTime + timeStep
-    call seq_timemgr_ETimeGet( nextTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( currTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( nextTime, ymd=NextYMD, tod=NextTOD )
 
     call datm_comp_run(clock, x2d, d2x, &
        SDATM, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, nextsw_cday, write_restart, &
-       currentYMD, currentTOD, case_name=case_name)
+       nextYMD, nextTOD, case_name=case_name)
 
     !--------------------------------
     ! Pack export state
@@ -706,41 +704,20 @@ module datm_comp_nuopc
     call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      rc=ESMF_Failure
-      call ESMF_LogWrite(subname//" ERROR in time consistency; "//trim(dtimestring)//" ne "//trim(mtimestring),  &
-           ESMF_LOGMSG_ERROR, rc=dbrc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    !--------------------------------
-    ! force the driver timestep into the model clock for consistency
-    ! by default, the model timestep is probably the slowest timestep in the system
-    ! while the driver timestep will be the timestep for this NUOPC slot
-    ! also update the model stop time for this timestep
-    !--------------------------------
+    !--------------------------------                                                                                 
+    ! force model clock currtime and timestep to match driver and set stoptime                                        
+    !--------------------------------                                                                                 
 
     mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !--------------------------------                                                                                 
+    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)                        
+    !--------------------------------                                                                                 
 
     call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    !--------------------------------
-    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
-    !--------------------------------
 
     if (alarmCount == 0) then
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
@@ -760,6 +737,16 @@ module datm_comp_nuopc
 
       deallocate(alarmList)
     endif
+
+    !--------------------------------                                                                                 
+    ! Advance model clock to trigger alarms then reset model clock back to currtime                                   
+    !--------------------------------                                                                                 
+
+    call ESMF_ClockAdvance(mclock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -240,20 +240,18 @@ CONTAINS
        if (read_restart) then
           if (trim(rest_file) == trim(nullstr)) then
              if (my_task == master_task) then
-                write(logunit,F00) ' restart filename from rpointer'
+                write(logunit,F00) ' restart filename from rpointer = ',trim(rpfile)
                 call shr_sys_flush(logunit)
                 inquire(file=trim(rpfile)//trim(inst_suffix),exist=exists)
-                if (.not. exists) then
-                   write(logunit,F00) ' ERROR: rpointer file does not exist'
-                   call shr_sys_abort(trim(subname)//' ERROR: rpointer file missing')
-                end if
-                nu = shr_file_getUnit()
-                open(nu, file=trim(rpfile)//trim(inst_suffix), form='formatted')
-                read(nu,'(a)') rest_file
-                close(nu)
-                call shr_file_freeUnit(nu)
-                inquire(file=trim(rest_file),exist=exists)
-             end if
+                if (exists) then
+                   nu = shr_file_getUnit()
+                   open(nu, file=trim(rpfile)//trim(inst_suffix), form='formatted')
+                   read(nu,'(a)') rest_file
+                   close(nu)
+                   call shr_file_freeUnit(nu)
+                   inquire(file=trim(rest_file),exist=exists)
+                endif
+             endif
              call shr_mpi_bcast(rest_file,mpicom,'rest_file')
           else
              ! use namelist already read

--- a/src/components/data_comps/dice/nuopc/dice_comp_nuopc.F90
+++ b/src/components/data_comps/dice/nuopc/dice_comp_nuopc.F90
@@ -10,7 +10,9 @@ module dice_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet
+  use seq_timemgr_mod       , only : seq_timemgr_EClockPrint, seq_timemgr_AlarmGet
+  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet, seq_timemgr_alarmSetOff
+  use seq_timemgr_mod       , only : seq_timemgr_alarm_restart, seq_timemgr_alarmIsOn
   use esmFlds               , only : fldListFr, fldListTo, compice, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
@@ -84,6 +86,7 @@ module dice_comp_nuopc
   logical                    :: unpack_import
   logical                    :: read_restart              ! start from restart
   character(CL)              :: case_name                 ! case name
+  character(CL)              :: tmpstr                    ! tmp string
   integer                    :: dbrc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
@@ -545,6 +548,8 @@ module dice_comp_nuopc
     logical                 :: write_restart ! restart alarm is ringing
     integer(IN)             :: currentYMD    ! model date
     integer(IN)             :: currentTOD    ! model sec into model date
+    integer(IN)             :: nextYMD       ! model date
+    integer(IN)             :: nextTOD       ! model sec into model date
     type(ESMF_Time)         :: currTime, nextTime
     type(ESMF_TimeInterval) :: timeStep
     character(len=*),parameter  :: subname=trim(modName)//':(ModelAdvance) '
@@ -584,17 +589,10 @@ module dice_comp_nuopc
     ! Run model
     !--------------------------------
 
-    call ESMF_ClockGetAlarm(clock, alarmname='seq_timemgr_alarm_restart', alarm=alarm, rc=rc)
+    write_restart = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-       write_restart = .true.
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_AlarmRingerOff( alarm, rc=rc )
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       write_restart = .false.
-    endif
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! For nuopc - the component clock is advanced at the end of the time interval
     ! For these to match for now - need to advance nuopc one timestep ahead for
@@ -602,13 +600,14 @@ module dice_comp_nuopc
     call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     nextTime = currTime + timeStep
-    call seq_timemgr_ETimeGet( nextTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( currTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( nextTime, ymd=NextYMD, tod=NextTOD )
 
     call dice_comp_run(clock, x2d, d2x, &
          flds_i2o_per_cat, &
          SDICE, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, logunit, read_restart, write_restart, &
-         currentYMD, currentTOD, case_name=case_name)
+         nextymd, nexttod, case_name=case_name)
 
     !--------------------------------
     ! Pack export state
@@ -673,6 +672,9 @@ module dice_comp_nuopc
     call NUOPC_ModelGet(gcomp, driverClock=dclock, modelClock=mclock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+!    call shr_nuopc_methods_Clock_TimePrint(dClock,trim(subname)//'driver clock1',rc)
+!    call shr_nuopc_methods_Clock_TimePrint(mclock,trim(subname)//'model  clock1',rc)
+
     call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -680,40 +682,19 @@ module dice_comp_nuopc
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      rc=ESMF_Failure
-
-      call ESMF_LogWrite(subname//" ERROR in time consistency; "//trim(dtimestring)//" ne "//trim(mtimestring),  &
-           ESMF_LOGMSG_ERROR, rc=dbrc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    !--------------------------------
-    ! force the driver timestep into the model clock for consistency
-    ! by default, the model timestep is probably the slowest timestep in the system
-    ! while the driver timestep will be the timestep for this NUOPC slot
-    ! also update the model stop time for this timestep
+    ! force model clock currtime and timestep to match driver and set stoptime
     !--------------------------------
 
     mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
     ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
     !--------------------------------
+
+    call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (alarmCount == 0) then
        call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
@@ -724,7 +705,7 @@ module dice_comp_nuopc
 
        do n = 1, alarmCount
           !call ESMF_AlarmPrint(alarmList(n), rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          !if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
           dalarm = ESMF_AlarmCreate(alarmList(n), rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
           call ESMF_AlarmSet(dalarm, clock=mclock, rc=rc)
@@ -733,6 +714,16 @@ module dice_comp_nuopc
 
        deallocate(alarmList)
     endif
+
+    !--------------------------------
+    ! Advance model clock to trigger alarms then reset model clock back to currtime
+    !--------------------------------
+
+    call ESMF_ClockAdvance(mclock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 

--- a/src/components/data_comps/dlnd/dlnd_comp_mod.F90
+++ b/src/components/data_comps/dlnd/dlnd_comp_mod.F90
@@ -19,7 +19,7 @@ module dlnd_comp_mod
   use shr_strdata_mod   , only: shr_strdata_advance, shr_strdata_restWrite
   use shr_dmodel_mod    , only: shr_dmodel_gsmapcreate, shr_dmodel_rearrGGrid
   use shr_dmodel_mod    , only: shr_dmodel_translate_list, shr_dmodel_translateAV_list, shr_dmodel_translateAV
-  use shr_cal_mod       , only: shr_cal_ymdtod2string
+  use shr_cal_mod       , only: shr_cal_datetod2string
   use seq_timemgr_mod   , only: seq_timemgr_EClockGetData
   use glc_elevclass_mod , only: glc_get_num_elevation_classes, glc_elevclass_as_string
 
@@ -125,7 +125,7 @@ CONTAINS
     integer(IN)        :: n,k        ! generic counters
     integer(IN)        :: ierr       ! error code
     integer(IN)        :: lsize      ! local size
-    logical            :: exists     ! file existance
+    logical            :: exists, exists1     ! file existance
     integer(IN)        :: nu         ! unit number
     character(CL)      :: calendar   ! model calendar
     integer(IN)        :: glc_nec    ! number of elevation classes
@@ -264,22 +264,24 @@ CONTAINS
     !----------------------------------------------------------------------------
 
     if (read_restart) then
-       if (trim(rest_file) == trim(nullstr) .and. trim(rest_file_strm) == trim(nullstr)) then
+       exists = .false.
+       exists1 = .false.
+       if (trim(rest_file)      == trim(nullstr) .and. &
+           trim(rest_file_strm) == trim(nullstr)) then
           if (my_task == master_task) then
-             write(logunit,F00) ' restart filenames from rpointer'
+             write(logunit,F00) ' restart filenames from rpointer = ',trim(rpfile)
              call shr_sys_flush(logunit)
              inquire(file=trim(rpfile)//trim(inst_suffix),exist=exists)
-             if (.not.exists) then
-                write(logunit,F00) ' ERROR: rpointer file does not exist'
-                call shr_sys_abort(trim(subname)//' ERROR: rpointer file missing')
+             if (exists) then
+                nu = shr_file_getUnit()
+                open(nu,file=trim(rpfile)//trim(inst_suffix),form='formatted')
+                read(nu,'(a)') rest_file
+                read(nu,'(a)') rest_file_strm
+                close(nu)
+                call shr_file_freeUnit(nu)
+                inquire(file=trim(rest_file_strm),exist=exists)
+                inquire(file=trim(rest_file),exist=exists1)
              endif
-             nu = shr_file_getUnit()
-             open(nu,file=trim(rpfile)//trim(inst_suffix),form='formatted')
-             read(nu,'(a)') rest_file
-             read(nu,'(a)') rest_file_strm
-             close(nu)
-             call shr_file_freeUnit(nu)
-             inquire(file=trim(rest_file_strm),exist=exists)
           endif
           call shr_mpi_bcast(rest_file,mpicom,'rest_file')
           call shr_mpi_bcast(rest_file_strm,mpicom,'rest_file_strm')
@@ -291,9 +293,18 @@ CONTAINS
              inquire(file=trim(rest_file_strm),exist=exists)
           endif
        endif
+
        call shr_mpi_bcast(exists,mpicom,'exists')
-       !if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file)
-       !call shr_pcdf_readwrite('read',trim(rest_file),mpicom,gsmap,rf1=somtp,rf1n='somtp')
+       call shr_mpi_bcast(exists1,mpicom,'exists1')
+
+       if (exists1) then
+          if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file)
+          call shr_pcdf_readwrite('read',SDLND%pio_subsystem, SDLND%io_type, &
+               trim(rest_file),mpicom,gsmap=gsmap,rf1=water,rf1n='water',io_format=SDLND%io_format)
+       else
+          if (my_task == master_task) write(logunit,F00) ' file not found, skipping ',trim(rest_file)
+       endif
+
        if (exists) then
           if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file_strm)
           call shr_strdata_restRead(trim(rest_file_strm),SDLND,mpicom)
@@ -331,7 +342,7 @@ CONTAINS
   subroutine dlnd_comp_run(EClock, x2l, l2x, &
        SDLND, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, read_restart, write_restart, &
-       currentYMD, currentTOD, case_name)
+       target_ymd, target_tod, case_name)
 
     ! !DESCRIPTION:  run method for dlnd model
     implicit none
@@ -351,8 +362,8 @@ CONTAINS
     integer(IN)            , intent(in)    :: logunit          ! logging unit number
     logical                , intent(in)    :: read_restart     ! start from restart
     logical                , intent(in)    :: write_restart    ! write restart
-    integer(IN)            , intent(in)    :: currentYMD       ! model date
-    integer(IN)            , intent(in)    :: currentTOD       ! model sec into model date
+    integer(IN)            , intent(in)    :: target_ymd       ! model date
+    integer(IN)            , intent(in)    :: target_tod       ! model sec into model date
     character(CL)          , intent(in), optional :: case_name ! case name
 
     !--- local ---
@@ -393,7 +404,7 @@ CONTAINS
           l2x%rAttr(kf,n) = lfrac(n)
        enddo
     end if
-    call shr_strdata_advance(SDLND,currentYMD,currentTOD,mpicom,'dlnd')
+    call shr_strdata_advance(SDLND,target_ymd,target_tod,mpicom,'dlnd')
     call t_stopf('dlnd_strdata_advance')
 
     call t_barrierf('dlnd_scatter_BARRIER',mpicom)
@@ -424,8 +435,7 @@ CONTAINS
 
     if (write_restart) then
        call t_startf('dlnd_restart')
-       call seq_timemgr_EClockGetData( EClock, curr_yr=yy, curr_mon=mm, curr_day=dd)
-       call shr_cal_ymdtod2string(date_str, yy,mm,dd,currentTOD)
+       call shr_cal_datetod2string(date_str, target_ymd, target_tod)
        write(rest_file,"(6a)") &
             trim(case_name), '.dlnd',trim(inst_suffix),'.r.', &
             trim(date_str),'.nc'
@@ -440,10 +450,10 @@ CONTAINS
           close(nu)
           call shr_file_freeUnit(nu)
        endif
-       !if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file),currentYMD,currentTOD
+       !if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file),target_ymd,target_tod
        !call shr_pcdf_readwrite('write',trim(rest_file),mpicom,gsmap,clobber=.true., &
        !   rf1=somtp,rf1n='somtp')
-       if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file_strm),currentYMD,currentTOD
+       if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file_strm),target_ymd,target_tod
        call shr_strdata_restWrite(trim(rest_file_strm),SDLND,mpicom,trim(case_name),'SDLND strdata')
        call shr_sys_flush(logunit)
        call t_stopf('dlnd_restart')
@@ -455,7 +465,7 @@ CONTAINS
 
     call t_startf('dlnd_run2')
     if (my_task == master_task) then
-       write(logunit,F04) trim(myModelName),': model date ', CurrentYMD,CurrentTOD
+       write(logunit,F04) trim(myModelName),': model date ', target_ymd,target_tod
        call shr_sys_flush(logunit)
     end if
     call t_stopf('dlnd_run2')

--- a/src/components/data_comps/dlnd/nuopc/dlnd_comp_nuopc.F90
+++ b/src/components/data_comps/dlnd/nuopc/dlnd_comp_nuopc.F90
@@ -10,7 +10,9 @@ module dlnd_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet
+  use seq_timemgr_mod       , only : seq_timemgr_EClockPrint
+  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet, seq_timemgr_alarmSetOff
+  use seq_timemgr_mod       , only : seq_timemgr_alarm_restart, seq_timemgr_alarmIsOn
   use esmFlds               , only : fldListFr, fldListTo, complnd, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
@@ -79,7 +81,8 @@ module dlnd_comp_nuopc
   integer(IN)                :: localPet
   logical                    :: lnd_prognostic            ! flag
   logical                    :: unpack_import
-    logical                  :: read_restart              ! start from restart
+  logical                    :: read_restart              ! start from restart
+  character(CL)              :: tmpstr                    ! tmp string
   integer                    :: dbrc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
@@ -489,6 +492,8 @@ module dlnd_comp_nuopc
     logical                 :: write_restart ! write restart
     integer(IN)             :: currentYMD    ! model date
     integer(IN)             :: currentTOD    ! model sec into model date
+    integer(IN)             :: nextYMD       ! model date
+    integer(IN)             :: nextTOD       ! model sec into model date
     type(ESMF_Time)         :: currTime, nextTime
     type(ESMF_TimeInterval) :: timeStep
     character(len=*),parameter :: subname=trim(modName)//':(ModelAdvance) '
@@ -528,29 +533,24 @@ module dlnd_comp_nuopc
     ! Run model
     !--------------------------------
 
-    call ESMF_ClockGetAlarm(clock, alarmname='seq_timemgr_alarm_restart', alarm=alarm, rc=rc)
+    write_restart = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       write_restart = .true.
-       call ESMF_AlarmRingerOff( alarm, rc=rc )
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       write_restart = .false.
-    endif
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! For nuopc - the component clock is advanced at the end of the time interval
     ! For these to match for now - need to advance nuopc one timestep ahead for
     ! shr_strdata time interpolation
-    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep)
+    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     nextTime = currTime + timeStep
-    call seq_timemgr_ETimeGet( nextTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( currTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( nextTime, ymd=NextYMD, tod=NextTOD )
 
     call dlnd_comp_run(Clock, x2d, d2x, &
        SDLND, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, read_restart, write_restart, &
-       currentYMD, currentTOD, case_name=case_name)
+       nextYMD, nextTOD, case_name=case_name)
 
     !--------------------------------
     ! Pack export state
@@ -616,40 +616,20 @@ module dlnd_comp_nuopc
     call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_LogWrite(subname//" ERROR in time consistency; "//trim(dtimestring)//" ne "//trim(mtimestring),  &
-           ESMF_LOGMSG_ERROR, rc=dbrc)
-      rc=ESMF_Failure
-    endif
-
-    !--------------------------------
-    ! force the driver timestep into the model clock for consistency
-    ! by default, the model timestep is probably the slowest timestep in the system
-    ! while the driver timestep will be the timestep for this NUOPC slot
-    ! also update the model stop time for this timestep
-    !--------------------------------
+    !--------------------------------                                                                                 
+    ! force model clock currtime and timestep to match driver and set stoptime                                        
+    !--------------------------------                                                                                 
 
     mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
     ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
     !--------------------------------
+
+    call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (alarmCount == 0) then
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
@@ -670,6 +650,16 @@ module dlnd_comp_nuopc
 
       deallocate(alarmList)
     endif
+
+    !--------------------------------                                                                                 
+    ! Advance model clock to trigger alarms then reset model clock back to currtime                                   
+    !--------------------------------                                                                                 
+
+    call ESMF_ClockAdvance(mclock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -20,7 +20,7 @@ module docn_comp_mod
   use shr_strdata_mod , only: shr_strdata_advance, shr_strdata_restWrite
   use shr_dmodel_mod  , only: shr_dmodel_gsmapcreate, shr_dmodel_rearrGGrid
   use shr_dmodel_mod  , only: shr_dmodel_translate_list, shr_dmodel_translateAV_list, shr_dmodel_translateAV
-  use shr_cal_mod     , only: shr_cal_ymdtod2string
+  use shr_cal_mod     , only: shr_cal_datetod2string
   use seq_timemgr_mod , only: seq_timemgr_EClockGetData
 
   use docn_shr_mod   , only: datamode       ! namelist input
@@ -124,7 +124,7 @@ CONTAINS
     integer(IN)   :: n,k      ! generic counters
     integer(IN)   :: ierr     ! error code
     integer(IN)   :: lsize    ! local size
-    logical       :: exists   ! file existance
+    logical       :: exists, exists1   ! file existance
     integer(IN)   :: nu       ! unit number
     character(CL) :: calendar ! model calendar
     integer(IN)   :: currentYMD    ! model date
@@ -282,22 +282,24 @@ CONTAINS
     !----------------------------------------------------------------------------
 
     if (read_restart) then
-       if (trim(rest_file) == trim(nullstr) .and. trim(rest_file_strm) == trim(nullstr)) then
+       exists = .false.
+       exists1 = .false.
+       if (trim(rest_file)      == trim(nullstr) .and. &
+           trim(rest_file_strm) == trim(nullstr)) then
           if (my_task == master_task) then
-             write(logunit,F00) ' restart filenames from rpointer'
+             write(logunit,F00) ' restart filenames from rpointer = ',trim(rpfile)
              call shr_sys_flush(logunit)
              inquire(file=trim(rpfile)//trim(inst_suffix),exist=exists)
-             if (.not.exists) then
-                write(logunit,F00) ' ERROR: rpointer file does not exist'
-                call shr_sys_abort(trim(subname)//' ERROR: rpointer file missing')
+             if (exists) then
+                nu = shr_file_getUnit()
+                open(nu,file=trim(rpfile)//trim(inst_suffix),form='formatted')
+                read(nu,'(a)') rest_file
+                read(nu,'(a)') rest_file_strm
+                close(nu)
+                call shr_file_freeUnit(nu)
+                inquire(file=trim(rest_file_strm),exist=exists)
+                inquire(file=trim(rest_file),exist=exists1)
              endif
-             nu = shr_file_getUnit()
-             open(nu,file=trim(rpfile)//trim(inst_suffix),form='formatted')
-             read(nu,'(a)') rest_file
-             read(nu,'(a)') rest_file_strm
-             close(nu)
-             call shr_file_freeUnit(nu)
-             inquire(file=trim(rest_file_strm),exist=exists)
           endif
           call shr_mpi_bcast(rest_file,mpicom,'rest_file')
           call shr_mpi_bcast(rest_file_strm,mpicom,'rest_file_strm')
@@ -309,12 +311,20 @@ CONTAINS
              inquire(file=trim(rest_file_strm),exist=exists)
           endif
        endif
+
        call shr_mpi_bcast(exists,mpicom,'exists')
+       call shr_mpi_bcast(exists1,mpicom,'exists1')
+
        if (trim(datamode) == 'SOM' .or. trim(datamode) == 'SOM_AQUAP') then
+       if (exists1) then
           if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file)
           call shr_pcdf_readwrite('read',SDOCN%pio_subsystem, SDOCN%io_type, &
                trim(rest_file), mpicom, gsmap=gsmap, rf1=somtp, rf1n='somtp', io_format=SDOCN%io_format)
+       else
+          if (my_task == master_task) write(logunit,F00) ' file not found, skipping ',trim(rest_file)
        endif
+       endif
+
        if (exists) then
           if (my_task == master_task) write(logunit,F00) ' reading ',trim(rest_file_strm)
           call shr_strdata_restRead(trim(rest_file_strm),SDOCN,mpicom)
@@ -358,7 +368,7 @@ CONTAINS
   subroutine docn_comp_run(EClock, x2o, o2x, &
        SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, read_restart, write_restart, &
-       currentYMD, currentTOD, case_name)
+       target_ymd, target_tod, case_name)
 
     ! !DESCRIPTION:  run method for docn model
     implicit none
@@ -378,8 +388,8 @@ CONTAINS
     integer(IN)            , intent(in)    :: logunit       ! logging unit number
     logical                , intent(in)    :: read_restart  ! start from restart
     logical                , intent(in)    :: write_restart ! restart alarm is on
-    integer(IN)            , intent(in)    :: currentYMD    ! model date
-    integer(IN)            , intent(in)    :: currentTOD    ! model sec into model date
+    integer(IN)            , intent(in)    :: target_ymd    ! model date
+    integer(IN)            , intent(in)    :: target_tod    ! model sec into model date
     character(len=*)       , intent(in), optional :: case_name ! case name
 
     !--- local ---
@@ -438,7 +448,7 @@ CONTAINS
     ! and thereby shr_strdata_advance does nothing
 
     call t_startf('docn_strdata_advance')
-    call shr_strdata_advance(SDOCN, currentYMD, currentTOD, mpicom, 'docn')
+    call shr_strdata_advance(SDOCN, target_ymd, target_tod, mpicom, 'docn')
     call t_stopf('docn_strdata_advance')
 
     !--- copy streams to o2x ---
@@ -595,26 +605,28 @@ CONTAINS
     ! Debug output
     !----------------------------------------------------------
 
+#if (1 == 0)
     if (dbug > 1 .and. my_task == master_task) then
        do n = 1,lsize
-          write(logunit,F01)'import: ymd,tod,n,Foxx_swnet = ', currentYMD, currentTOD, n, x2o%rattr(kswnet,n)    
-          write(logunit,F01)'import: ymd,tod,n,Foxx_lwup  = ', currentYMD, currentTOD, n, x2o%rattr(klwup,n)    
-          write(logunit,F01)'import: ymd,tod,n,Foxx_lwdn  = ', currentYMD, currentTOD, n, x2o%rattr(klwdn,n)    
-          write(logunit,F01)'import: ymd,tod,n,Fioi_melth = ', currentYMD, currentTOD, n, x2o%rattr(kmelth,n)    
-          write(logunit,F01)'import: ymd,tod,n,Foxx_sen   = ', currentYMD, currentTOD, n, x2o%rattr(ksen,n)    
-          write(logunit,F01)'import: ymd,tod,n,Foxx_lat   = ', currentYMD, currentTOD, n, x2o%rattr(klat,n)    
-          write(logunit,F01)'import: ymd,tod,n,Foxx_rofi  = ', currentYMD, currentTOD, n, x2o%rattr(krofi,n)    
+          write(logunit,F01)'import: ymd,tod,n,Foxx_swnet = ', target_ymd, target_tod, n, x2o%rattr(kswnet,n)    
+          write(logunit,F01)'import: ymd,tod,n,Foxx_lwup  = ', target_ymd, target_tod, n, x2o%rattr(klwup,n)    
+          write(logunit,F01)'import: ymd,tod,n,Foxx_lwdn  = ', target_ymd, target_tod, n, x2o%rattr(klwdn,n)    
+          write(logunit,F01)'import: ymd,tod,n,Fioi_melth = ', target_ymd, target_tod, n, x2o%rattr(kmelth,n)    
+          write(logunit,F01)'import: ymd,tod,n,Foxx_sen   = ', target_ymd, target_tod, n, x2o%rattr(ksen,n)    
+          write(logunit,F01)'import: ymd,tod,n,Foxx_lat   = ', target_ymd, target_tod, n, x2o%rattr(klat,n)    
+          write(logunit,F01)'import: ymd,tod,n,Foxx_rofi  = ', target_ymd, target_tod, n, x2o%rattr(krofi,n)    
 
-          write(logunit,F01)'export: ymd,tod,n,So_t       = ', currentYMD, currentTOD, n, o2x%rattr(kt,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_s       = ', currentYMD, currentTOD, n, o2x%rattr(ks,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_u       = ', currentYMD, currentTOD, n, o2x%rattr(ku,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_v       = ', currentYMD, currentTOD, n, o2x%rattr(kv,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_dhdx    = ', currentYMD, currentTOD, n, o2x%rattr(kdhdx,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_dhdy    = ', currentYMD, currentTOD, n, o2x%rattr(kdhdy,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_fswpen  = ', currentYMD, currentTOD, n, o2x%rattr(kswp,n)    
-          write(logunit,F01)'export: ymd,tod,n,Fioo_q     = ', currentYMD, currentTOD, n, o2x%rattr(kq,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_t       = ', target_ymd, target_tod, n, o2x%rattr(kt,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_s       = ', target_ymd, target_tod, n, o2x%rattr(ks,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_u       = ', target_ymd, target_tod, n, o2x%rattr(ku,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_v       = ', target_ymd, target_tod, n, o2x%rattr(kv,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_dhdx    = ', target_ymd, target_tod, n, o2x%rattr(kdhdx,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_dhdy    = ', target_ymd, target_tod, n, o2x%rattr(kdhdy,n)    
+          write(logunit,F01)'export: ymd,tod,n,So_fswpen  = ', target_ymd, target_tod, n, o2x%rattr(kswp,n)    
+          write(logunit,F01)'export: ymd,tod,n,Fioo_q     = ', target_ymd, target_tod, n, o2x%rattr(kq,n)    
        end do
     end if
+#endif
 
     !--------------------
     ! Write restart
@@ -622,8 +634,7 @@ CONTAINS
 
     if (write_restart) then
        call t_startf('docn_restart')
-       call seq_timemgr_EClockGetData( EClock, curr_yr=yy, curr_mon=mm, curr_day=dd, curr_tod=tod)
-       call shr_cal_ymdtod2string(date_str, yy,mm,dd,currentTOD)
+       call shr_cal_datetod2string(date_str, target_ymd, target_tod)
        write(rest_file,"(6a)") &
             trim(case_name), '.docn',trim(inst_suffix),'.r.', &
             trim(date_str),'.nc'
@@ -639,11 +650,11 @@ CONTAINS
           call shr_file_freeUnit(nu)
        endif
        if (trim(datamode) == 'SOM' .or. trim(datamode) == 'SOM_AQUAP') then
-          if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file),currentYMD,currentTOD
+          if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file),target_ymd,target_tod
           call shr_pcdf_readwrite('write', SDOCN%pio_subsystem, SDOCN%io_type,&
                trim(rest_file), mpicom, gsmap, clobber=.true., rf1=somtp,rf1n='somtp')
        endif
-       if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file_strm),currentYMD,currentTOD
+       if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file_strm),target_ymd,target_tod
        call shr_strdata_restWrite(trim(rest_file_strm), SDOCN, mpicom, trim(case_name), 'SDOCN strdata')
        call shr_sys_flush(logunit)
        call t_stopf('docn_restart')
@@ -657,7 +668,7 @@ CONTAINS
 
     call t_startf('docn_run2')
     if (my_task == master_task) then
-       write(logunit,F04) trim(myModelName),': model date ', CurrentYMD,CurrentTOD
+       write(logunit,F04) trim(myModelName),': model date ', target_ymd,target_tod
        call shr_sys_flush(logunit)
     end if
 

--- a/src/components/data_comps/docn/nuopc/docn_comp_nuopc.F90
+++ b/src/components/data_comps/docn/nuopc/docn_comp_nuopc.F90
@@ -10,7 +10,9 @@ module docn_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_getUnit
-  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet
+  use seq_timemgr_mod       , only : seq_timemgr_EClockPrint
+  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet, seq_timemgr_alarmSetOff
+  use seq_timemgr_mod       , only : seq_timemgr_alarm_restart, seq_timemgr_alarmIsOn
   use esmFlds               , only : fldListFr, fldListTo, compocn, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
@@ -82,6 +84,7 @@ module docn_comp_nuopc
   logical                    :: unpack_import
   logical                    :: read_restart              ! start from restart
   character(CL)              :: case_name                 ! case name
+  character(CL)              :: tmpstr                    ! tmp string
   integer                    :: dbrc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
@@ -529,6 +532,8 @@ module docn_comp_nuopc
     logical                 :: write_restart ! restart alarm is ringing
     integer(IN)             :: currentYMD    ! model date
     integer(IN)             :: currentTOD    ! model sec into model date
+    integer(IN)             :: nextYMD       ! model date
+    integer(IN)             :: nextTOD       ! model sec into model date
     type(ESMF_Time)         :: currTime, nextTime
     type(ESMF_TimeInterval) :: timeStep
     character(len=*),parameter  :: subname=trim(modName)//':(ModelAdvance) '
@@ -563,36 +568,31 @@ module docn_comp_nuopc
 
     if (unpack_import) then
        call shr_nuopc_grid_StateToArray(importState, x2d%rattr, flds_x2o, grid_option, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     !--------------------------------
     ! Run model
     !--------------------------------
 
-    call ESMF_ClockGetAlarm(clock, alarmname='seq_timemgr_alarm_restart', alarm=alarm, rc=rc)
+    write_restart = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       write_restart = .true.
-       call ESMF_AlarmRingerOff( alarm, rc=rc )
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       write_restart = .false.
-    endif
 
     ! For nuopc - the component clock is advanced at the end of the time interval
     ! For these to match for now - need to advance nuopc one timestep ahead for
     ! shr_strdata time interpolation
-    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep)
+    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     nextTime = currTime + timeStep
-    call seq_timemgr_ETimeGet( nextTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( currTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( nextTime, ymd=NextYMD, tod=NextTOD )
 
     call docn_comp_run(clock, x2d, d2x, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, logunit, read_restart, write_restart, &
-         currentYMD, currentTOD, case_name=case_name)
+         nextYMD, nextTOD, case_name=case_name)
 
     !--------------------------------
     ! Pack export state
@@ -667,62 +667,49 @@ module docn_comp_nuopc
     call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      rc=ESMF_Failure
-
-      call ESMF_LogWrite(subname//" ERROR in time consistency; "//trim(dtimestring)//" ne "//trim(mtimestring),  &
-           ESMF_LOGMSG_ERROR, rc=dbrc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    !--------------------------------
-    ! force the driver timestep into the model clock for consistency
-    ! by default, the model timestep is probably the slowest timestep in the system
-    ! while the driver timestep will be the timestep for this NUOPC slot
-    ! also update the model stop time for this timestep
-    !--------------------------------
+    !--------------------------------                                                                                 
+    ! force model clock currtime and timestep to match driver and set stoptime                                        
+    !--------------------------------                                                                                 
 
     mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !--------------------------------                                                                                 
+    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)                        
+    !--------------------------------                                                                                 
 
     call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
-    !--------------------------------
-
     if (alarmCount == 0) then
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(alarmList(alarmCount))
-
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmList=alarmList, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       do n = 1, alarmCount
          ! call ESMF_AlarmPrint(alarmList(n), rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         !if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
          dalarm = ESMF_AlarmCreate(alarmList(n), rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
          call ESMF_AlarmSet(dalarm, clock=mclock, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
       enddo
 
       deallocate(alarmList)
     endif
+
+    !--------------------------------                                                                                 
+    ! Advance model clock to trigger alarms then reset model clock back to currtime                                   
+    !--------------------------------                                                                                 
+
+    call ESMF_ClockAdvance(mclock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 

--- a/src/components/data_comps/drof/nuopc/drof_comp_nuopc.F90
+++ b/src/components/data_comps/drof/nuopc/drof_comp_nuopc.F90
@@ -10,7 +10,9 @@ module drof_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet
+  use seq_timemgr_mod       , only : seq_timemgr_EClockPrint
+  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet, seq_timemgr_alarmSetOff
+  use seq_timemgr_mod       , only : seq_timemgr_alarm_restart, seq_timemgr_alarmIsOn
   use esmFlds               , only : fldListFr, fldListTo, comprof, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
@@ -85,6 +87,7 @@ module drof_comp_nuopc
   logical                    :: unpack_import
   logical                    :: read_restart              ! start from restart
   character(CL)              :: case_name                 ! case name
+  character(CL)              :: tmpstr                    ! tmp string
   integer                    :: dbrc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
@@ -519,6 +522,8 @@ module drof_comp_nuopc
     logical                 :: write_restart ! write restart
     integer(IN)             :: currentYMD    ! model date
     integer(IN)             :: currentTOD    ! model sec into model date
+    integer(IN)             :: nextYMD       ! model date
+    integer(IN)             :: nextTOD       ! model sec into model date
     type(ESMF_Time)         :: currTime, nextTime
     type(ESMF_TimeInterval) :: timeStep
     character(len=*),parameter :: subname=trim(modName)//':(ModelAdvance) '
@@ -553,36 +558,31 @@ module drof_comp_nuopc
 
     if (unpack_import) then
        call shr_nuopc_grid_StateToArray(importState, x2d%rattr, flds_x2r, grid_option, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     !--------------------------------
     ! Run model
     !--------------------------------
 
-    call ESMF_ClockGetAlarm(clock, alarmname='seq_timemgr_alarm_restart', alarm=alarm, rc=rc)
+    write_restart = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       write_restart = .true.
-       call ESMF_AlarmRingerOff( alarm, rc=rc )
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       write_restart = .false.
-    endif
 
     ! For nuopc - the component clock is advanced at the end of the time interval
     ! For these to match for now - need to advance nuopc one timestep ahead for
     ! shr_strdata time interpolation
-    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep)
+    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     nextTime = currTime + timeStep
-    call seq_timemgr_ETimeGet( nextTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( currTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( nextTime, ymd=NextYMD, tod=NextTOD )
 
     call drof_comp_run(clock, x2d, d2x, &
        SDROF, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, read_restart, write_restart, &
-         currentYMD, currentTOD, case_name=case_name)
+         nextYMD, nextTOD, case_name=case_name)
 
     !--------------------------------
     ! Pack export state
@@ -651,60 +651,53 @@ module drof_comp_nuopc
 
     call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      rc=ESMF_Failure
-      call ESMF_LogWrite(subname//" ERROR in time consistency; "//trim(dtimestring)//" ne "//trim(mtimestring),  ESMF_LOGMSG_ERROR, rc=dbrc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    !--------------------------------
-    ! force the driver timestep into the model clock for consistency
-    ! by default, the model timestep is probably the slowest timestep in the system
-    ! while the driver timestep will be the timestep for this NUOPC slot
-    ! also update the model stop time for this timestep
-    !--------------------------------
+    !--------------------------------                                                                                 
+    ! force model clock currtime and timestep to match driver and set stoptime                                        
+    !--------------------------------                                                                                 
 
     mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !--------------------------------                                                                                 
+    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)                        
+    !--------------------------------                                                                                 
 
     call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
-    !--------------------------------
-
     if (alarmCount == 0) then
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(alarmList(alarmCount))
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmList=alarmList, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       do n = 1, alarmCount
-!         call ESMF_AlarmPrint(alarmList(n), rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         !call ESMF_AlarmPrint(alarmList(n), rc=rc)
+         !if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
          dalarm = ESMF_AlarmCreate(alarmList(n), rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
          call ESMF_AlarmSet(dalarm, clock=mclock, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
       enddo
 
       deallocate(alarmList)
     endif
+
+    !--------------------------------                                                                                 
+    ! Advance model clock to trigger alarms then reset model clock back to currtime                                   
+    !--------------------------------                                                                                 
+
+    call ESMF_ClockAdvance(mclock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 

--- a/src/components/data_comps/dwav/nuopc/dwav_comp_nuopc.F90
+++ b/src/components/data_comps/dwav/nuopc/dwav_comp_nuopc.F90
@@ -10,7 +10,9 @@ module dwav_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet
+  use seq_timemgr_mod       , only : seq_timemgr_EClockPrint
+  use seq_timemgr_mod       , only : seq_timemgr_ETimeGet, seq_timemgr_alarmSetOff
+  use seq_timemgr_mod       , only : seq_timemgr_alarm_restart, seq_timemgr_alarmIsOn
   use esmFlds               , only : fldListFr, fldListTo, compwav, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
@@ -82,6 +84,7 @@ module dwav_comp_nuopc
   logical                    :: read_restart              ! start from restart
   logical                    :: wav_prognostic            ! flag
   logical                    :: unpack_import
+  character(CL)              :: tmpstr                    ! tmp string
   integer                    :: dbrc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
@@ -486,6 +489,8 @@ module dwav_comp_nuopc
     logical                 :: write_restart ! write a restart
     integer(IN)             :: currentYMD    ! model date
     integer(IN)             :: currentTOD    ! model sec into model date
+    integer(IN)             :: nextYMD       ! model date
+    integer(IN)             :: nextTOD       ! model sec into model date
     type(ESMF_Time)         :: currTime, nextTime
     type(ESMF_TimeInterval) :: timeStep
     character(len=*),parameter :: subname=trim(modName)//':(ModelAdvance) '
@@ -507,7 +512,7 @@ module dwav_comp_nuopc
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 1) then
-       if (master_task) then
+       if (my_task == master_task) then
           call shr_nuopc_methods_Clock_TimePrint(clock,subname//'clock',rc=rc)
        end if
     endif
@@ -525,17 +530,10 @@ module dwav_comp_nuopc
     ! Run model
     !--------------------------------
 
-    call ESMF_ClockGetAlarm(clock, alarmname='seq_timemgr_alarm_restart', alarm=alarm, rc=rc)
+    write_restart = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       write_restart = .true.
-       call ESMF_AlarmRingerOff( alarm, rc=rc )
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       write_restart = .false.
-    endif
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! For nuopc - the component clock is advanced at the end of the time interval
     ! For these to match for now - need to advance nuopc one timestep ahead for
@@ -543,12 +541,13 @@ module dwav_comp_nuopc
     call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     nextTime = currTime + timeStep
-    call seq_timemgr_ETimeGet( nextTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( currTime, ymd=CurrentYMD, tod=CurrentTOD )
+    call seq_timemgr_ETimeGet( nextTime, ymd=NextYMD, tod=NextTOD )
 
     call dwav_comp_run(clock, x2d, d2x, &
        SDWAV, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, read_restart, write_restart, &
-       currentYMD, currentTOD, case_name=case_name)
+       nextYMD, nextTOD, case_name=case_name)
 
     !--------------------------------
     ! Pack export state
@@ -569,7 +568,7 @@ module dwav_comp_nuopc
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    if (master_task) then
+    if (my_task == master_task) then
        call ESMF_ClockPrint(clock, options="currTime", preString="------>Advancing WAV from: ", rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -610,50 +609,29 @@ module dwav_comp_nuopc
 
     call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-      rc=ESMF_Failure
-      call ESMF_LogWrite(subname//" ERROR in time consistency; "//trim(dtimestring)//" ne "//trim(mtimestring),  &
-           ESMF_LOGMSG_ERROR, rc=dbrc)
-      return
-    endif
-
-    !--------------------------------
-    ! force the driver timestep into the model clock for consistency
-    ! by default, the model timestep is probably the slowest timestep in the system
-    ! while the driver timestep will be the timestep for this NUOPC slot
-    ! also update the model stop time for this timestep
-    !--------------------------------
+    !--------------------------------                                                                                 
+    ! force model clock currtime and timestep to match driver and set stoptime                                        
+    !--------------------------------                                                                                 
 
     mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !--------------------------------                                                                                 
+    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)                        
+    !--------------------------------                                                                                 
 
     call ESMF_ClockGetAlarmList(mclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    !--------------------------------
-    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
-    !--------------------------------
 
     if (alarmCount == 0) then
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(alarmList(alarmCount))
-
       call ESMF_ClockGetAlarmList(dclock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmList=alarmList, rc=rc)
       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -668,6 +646,16 @@ module dwav_comp_nuopc
 
       deallocate(alarmList)
     endif
+
+    !--------------------------------                                                                                 
+    ! Advance model clock to trigger alarms then reset model clock back to currtime                                   
+    !--------------------------------                                                                                 
+
+    call ESMF_ClockAdvance(mclock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 

--- a/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
@@ -76,11 +76,12 @@
 	    #
             ATM -> MED :remapMethod=redist
             MED med_connectors_post_atm2med
-            MED med_phases_history
+            MED med_phases_history_write
 	  @
 	  OCN
   	  OCN -> MED :remapMethod=redist
 	  MED med_connectors_post_ocn2med
+          MED med_phases_restart_write
       @
       </value>
       <value COMP_OCN="socn">
@@ -123,8 +124,9 @@
             MED med_connectors_post_glc2med
             ATM -> MED :remapMethod=redist
             MED med_connectors_post_atm2med
-            MED med_phases_history
+            MED med_phases_history_write
 	  @
+          MED med_phases_restart_write
        @
       </value>
       <value COMP_ATM="cam" COMP_OCN="docn" COMP_WAV="swav">
@@ -167,8 +169,9 @@
 	    ATM
 	    ATM -> MED :remapMethod=redist
 	    MED med_connectors_post_atm2med
-            MED med_phases_history
+            MED med_phases_history_write
 	  @
+          MED med_phases_restart_write
        @
       </value>
     </values>
@@ -688,24 +691,24 @@
     </values>
   </entry>
 
-  <entry id="restart_pfile">
+  <entry id="driver_restart_pfile">
     <type>char</type>
     <category>expdef</category>
     <group>DRIVER_attributes</group>
     <desc>
-      Driver restart pointer file.
+      Mediator restart pointer file.
     </desc>
     <values>
-      <value>rpointer.drv</value>
+      <value>rpointer.med</value>
     </values>
   </entry>
 
-  <entry id="restart_file">
+  <entry id="driver_restart_file">
     <type>char</type>
     <category>expdef</category>
     <group>DRIVER_attributes</group>
     <desc>
-      Full archive path to restart file
+      Full archive path to restart file for mediator
     </desc>
     <values>
       <value>str_undefined</value>
@@ -955,6 +958,30 @@
   <!-- =========================================== -->
   <!-- MED general attributes                      -->
   <!-- =========================================== -->
+
+  <entry id="restart_pfile">
+    <type>char</type>
+    <category>expdef</category>
+    <group>MED_attributes</group>
+    <desc>
+      Mediator restart pointer file.
+    </desc>
+    <values>
+      <value>rpointer.med</value>
+    </values>
+  </entry>
+
+  <entry id="restart_file">
+    <type>char</type>
+    <category>expdef</category>
+    <group>MED_attributes</group>
+    <desc>
+      Full archive path to restart file for mediator
+    </desc>
+    <values>
+      <value>str_undefined</value>
+    </values>
+  </entry>
 
   <entry id="flux_convergence">
     <type>real</type>

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -1211,49 +1211,6 @@ module ESM
     call NUOPC_CompAttributeSet(driver, name='read_restart', value=trim(cvalue), rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! TODO: Read Restart (seq_io_read must be called on all pes)
-
-    ! Error check on restart_pfile
-    call NUOPC_CompAttributeGet(driver, name="restart_pfile", value=restart_pfile, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if ( len_trim(restart_pfile) == 0 ) then
-       write (msgstr, *) subname//': restart_pfile must be set' 
-       call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-       return  
-    end if
-
-    if (read_restart) then
-       if (mastertask) then
-          call NUOPC_CompAttributeGet(driver, name='restart_file', value=restart_file, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          !--- read rpointer if restart_file is set to sp_str ---
-          if (trim(restart_file) == trim(sp_str)) then
-             call NUOPC_CompAttributeGet(driver, name='restart_pfile', value=restart_file, rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             unitn = shr_file_getUnit()
-             if (loglevel > 0) write(logunit,"(3A)") subname," read rpointer file ", trim(restart_pfile)
-             open(unitn, file=restart_pfile, form='FORMATTED', status='old',iostat=ierr)
-             if (ierr < 0) then
-                call shr_sys_abort( subname//':: rpointer file open returns an'// ' error condition' )
-             end if
-             read(unitn,'(a)', iostat=ierr) restart_file
-             if (ierr < 0) then
-                call shr_sys_abort( subname//':: rpointer file read returns an'// ' error condition' )
-             end if
-             close(unitn)
-             call shr_file_freeUnit( unitn )
-             write(logunit,"(3A)") subname,' restart file from rpointer= ', trim(restart_file)
-          endif
-       endif
-       call shr_mpi_bcast(restart_file, lmpicom)
-
-       call NUOPC_CompAttributeSet(driver, name='restart_pfile', value=restart_file, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
   end subroutine InitRestart
 
   !================================================================================

--- a/src/drivers/nuopc/mediator/med.F90
+++ b/src/drivers/nuopc/mediator/med.F90
@@ -74,7 +74,8 @@ module MED
   use med_phases_ocnalb_mod     , only: med_phases_ocnalb_run
   use med_phases_aofluxes_mod   , only: med_phases_aofluxes_init 
   use med_phases_aofluxes_mod   , only: med_phases_aofluxes_run
-  use med_phases_history_mod    , only: med_phases_history
+  use med_phases_history_mod    , only: med_phases_history_write
+  use med_phases_restart_mod    , only: med_phases_restart_write, med_phases_restart_read
   use med_fraction_mod          , only: med_fraction_init, med_fraction_set
   use med_constants_mod         , only: med_constants_dbug_flag
   use med_constants_mod         , only: med_constants_spval_init
@@ -190,10 +191,21 @@ contains
     !------------------
 
     call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_RUN, &
-         phaseLabelList=(/"med_phases_history"/), userRoutine=mediator_routine_Run, rc=rc)
+         phaseLabelList=(/"med_phases_history_write"/), userRoutine=mediator_routine_Run, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     call NUOPC_CompSpecialize(gcomp, specLabel=mediator_label_Advance, &
-         specPhaseLabel="med_phases_history", specRoutine=med_phases_history, rc=rc)
+         specPhaseLabel="med_phases_history_write", specRoutine=med_phases_history_write, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !------------------
+    ! setup mediator restart phase
+    !------------------
+
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_RUN, &
+         phaseLabelList=(/"med_phases_restart_write"/), userRoutine=mediator_routine_Run, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call NUOPC_CompSpecialize(gcomp, specLabel=mediator_label_Advance, &
+         specPhaseLabel="med_phases_restart_write", specRoutine=med_phases_restart_write, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !------------------
@@ -1284,6 +1296,8 @@ contains
     character(ESMF_MAXSTR),allocatable :: fieldNameList(:)
     character(len=128)                 :: value
     character(SHR_KIND_CL)             :: cvalue
+    character(SHR_KIND_CL)             :: start_type
+    logical                            :: read_restart
     logical                            :: LocalDone
     logical,save                       :: atmDone = .false.
     logical,save                       :: ocnDone = .false.
@@ -1489,28 +1503,6 @@ contains
          enddo
       enddo
       if (mastertask) call shr_sys_flush(llogunit)
-
-#if (1 == 0)
-      !---------------------------------------
-      ! read mediator restarts
-      !---------------------------------------
-      !---tcraig, turn if on to force no mediator restarts for testing
-      !if (.not.coldstart) then
-        call Mediator_restart(gcomp,'read','mediator',rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      !endif
-
-      ! default initialize s_surf to work around limitations of current initialization sequence
-      call ESMF_StateGet(is_local%wrap%NStateExp(compice), itemName='s_surf', itemType=itemType, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      if (itemType /= ESMF_STATEITEM_NOTFOUND) then
-        if (NUOPC_IsConnected(is_local%wrap%NStateExp(compice),'s_surf',rc=rc)) then
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call State_SetFldPtr(is_local%wrap%NStateExp(compice), 's_surf', 34.0_ESMF_KIND_R8, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        endif
-      endif
-#endif
 
       !---------------------------------------
       !--- Initialize route handles and required normalization field bunds
@@ -1842,6 +1834,23 @@ contains
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call med_io_cpl_init()
+
+      !---------------------------------------
+      ! read mediator restarts
+      !---------------------------------------
+
+       call NUOPC_CompAttributeGet(gcomp, name="read_restart", value=cvalue, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call ESMF_LogWrite(subname//' read_restart = '//trim(cvalue), ESMF_LOGMSG_INFO, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) read_restart
+
+       if (read_restart) then
+         call med_phases_restart_read(gcomp, rc)
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       endif
+
     else
        call NUOPC_CompAttributeSet(gcomp, name="InitializeDataComplete", value="false", rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1866,6 +1875,9 @@ contains
     type(ESMF_Clock)           :: mediatorClock, driverClock
     type(ESMF_Time)            :: currTime
     type(ESMF_TimeInterval)    :: timeStep
+    type(ESMF_Alarm),pointer   :: alarmList(:)
+    type(ESMF_Alarm)           :: dalarm
+    integer                    :: alarmcount, n
     character(len=*),parameter :: subname='(module_MED:SetRunClock)'
     !-----------------------------------------------------------
 
@@ -1900,196 +1912,47 @@ contains
     call NUOPC_CompCheckSetClock(gcomp, driverClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    !--------------------------------
+    ! copy alarms from driver to model clock if model clock has no alarms (do this only once!)
+    !--------------------------------
+
+    call ESMF_ClockGetAlarmList(mediatorClock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if (alarmCount == 0) then
+      call ESMF_ClockGetAlarmList(driverClock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmCount=alarmCount, rc=rc)
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      allocate(alarmList(alarmCount))
+      call ESMF_ClockGetAlarmList(driverClock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmList=alarmList, rc=rc)
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+      do n = 1, alarmCount
+         !call ESMF_AlarmPrint(alarmList(n), rc=rc)
+         !if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         dalarm = ESMF_AlarmCreate(alarmList(n), rc=rc)
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+         call ESMF_AlarmSet(dalarm, clock=mediatorClock, rc=rc)
+         if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      enddo
+
+      deallocate(alarmList)
+    endif
+
+    !--------------------------------
+    ! Advance med clock to trigger alarms then reset model clock back to currtime
+    !--------------------------------
+
+    call ESMF_ClockAdvance(mediatorClock,rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockSet(mediatorClock, currTime=currtime, timeStep=timestep, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
     if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
     endif
 
   end subroutine SetRunClock
-
-  !-----------------------------------------------------------------------------
-#if (1 == 0)
-
-  subroutine Mediator_restart(gcomp,mode,bfname,rc)
-    !
-    ! read/write mediator restart file
-    !
-    type(ESMF_GridComp)  :: gcomp
-    character(len=*), intent(in)    :: mode
-    character(len=*), intent(in)    :: bfname
-    integer         , intent(inout) :: rc
-
-    type(InternalState)  :: is_local
-    character(len=1280)  :: fname
-    integer              :: funit
-    logical              :: fexists
-    character(len=*),parameter :: subname='(module_MED:Mediator_restart)'
-    !-----------------------------------------------------------
-
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-    rc = ESMF_SUCCESS
-
-    if (mode /= 'write' .and. mode /= 'read') then
-       call ESMF_LogWrite(trim(subname)//": ERROR mode not allowed "//trim(mode), &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-      rc = ESMF_FAILURE
-      return
-    endif
-
-    ! Get the internal state from Component.
-    nullify(is_local%wrap)
-    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(compatm)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(compatm),read_rest_FBaccum(compatm),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(compocn)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(compocn),read_rest_FBaccum(compocn),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(compice)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(compice),read_rest_FBaccum(compice),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(complnd)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(complnd),read_rest_FBaccum(complnd),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(comprof)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(comprof),read_rest_FBaccum(comprof),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(compwav)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(compwav),read_rest_FBaccum(compwav),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccum(compglc)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccum(compglc),read_rest_FBaccum(compglc),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBaccumAOflux_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaccumAOflux,read_rest_FBaccumAOflux,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    fname = trim(bfname)//'_FBAtm_a_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(compatm,compatm),read_rest_FBAtm_a,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(compatm), is_local%wrap%FBImp(compatm,compatm), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBImp(compice,compice)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(compice,compice),read_rest_FBImp(compice,compice),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(compice), is_local%wrap%FBImp(compice,compice), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBImp(compocn,compocn)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(compocn,compocn),read_rest_FBImp(compocn,compocn),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(compocn), is_local%wrap%FBImp(compocn,compocn), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBImp(complnd,complnd)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(complnd,complnd),read_rest_FBImp(complnd,complnd),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(complnd), is_local%wrap%FBImp(complnd,complnd), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBImp(comprof,comprof)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(comprof,comprof),read_rest_FBImp(comprof,comprof),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(comprof), is_local%wrap%FBImp(comprof,comprof), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBImp(compwav,comprof)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(compwav,comprof),read_rest_FBImp(compwav,comprof),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(compwav), is_local%wrap%FBImp(compwav,comprof), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBImp(compglc,comprof)_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBImp(compglc,comprof),read_rest_FBImp(compglc,comprof),rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mode == 'read') then
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateImp(compglc), is_local%wrap%FBImp(compglc,comprof), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    fname = trim(bfname)//'_FBAOFlux_o_restart.nc'
-    call FieldBundle_RWFields(mode,fname,is_local%wrap%FBaoflux_o,read_rest_FBaoflux_o,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    funit = 1101
-    fname = trim(bfname)//'_scalars_restart.txt'
-    if (mode == 'write') then
-      call ESMF_LogWrite(trim(subname)//": write "//trim(fname), ESMF_LOGMSG_INFO, rc=dbrc)
-      open(funit,file=fname,form='formatted')
-      write(funit,*) is_local%wrap%FBaccumcnt(compatm)
-      write(funit,*) is_local%wrap%FBaccumcnt(compocn)
-      write(funit,*) is_local%wrap%FBaccumcnt(compice)
-      write(funit,*) is_local%wrap%FBaccumcntAOflux
-      write(funit,*) is_local%wrap%FBaccumcnt(complnd)
-      write(funit,*) is_local%wrap%FBaccumcnt(comprof)
-      write(funit,*) is_local%wrap%FBaccumcnt(compwav)
-      write(funit,*) is_local%wrap%FBaccumcnt(compglc)
-      close(funit)
-    elseif (mode == 'read') then
-      inquire(file=fname,exist=fexists)
-      if (fexists) then
-        call ESMF_LogWrite(trim(subname)//": read "//trim(fname), ESMF_LOGMSG_INFO, rc=dbrc)
-        open(funit,file=fname,form='formatted')
-        ! DCR - temporary skip reading Lnd and Rof until components are added to test case
-        !       restart files
-        is_local%wrap%FBaccumcnt(compatm)=0
-        is_local%wrap%FBaccumcnt(compocn)=0
-        is_local%wrap%FBaccumcnt(compice)=0
-        is_local%wrap%FBaccumcntAOflux=0
-        is_local%wrap%FBaccumcnt(complnd)=0
-        is_local%wrap%FBaccumcnt(comprof)=0
-        is_local%wrap%FBaccumcnt(compwav)=0
-        is_local%wrap%FBaccumcnt(compglc)=0
-        read (funit,*) is_local%wrap%FBaccumcnt(compatm)
-        read (funit,*) is_local%wrap%FBaccumcnt(compocn)
-        read (funit,*) is_local%wrap%FBaccumcnt(compice)
-        read (funit,*) is_local%wrap%FBaccumcntAOflux
-        read (funit,*) is_local%wrap%FBaccumcnt(complnd)
-        read (funit,*) is_local%wrap%FBaccumcnt(comprof)
-        read (funit,*) is_local%wrap%FBaccumcnt(compwav)
-        read (funit,*) is_local%wrap%FBaccumcnt(compglc)
-        close(funit)
-      else
-        read_rest_FBaccum(compatm) = .false.
-        read_rest_FBaccum(compocn) = .false.
-        read_rest_FBaccum(compice) = .false.
-        read_rest_FBaccum(complnd) = .false.
-        read_rest_FBaccum(comprof) = .false.
-        read_rest_FBaccum(compwav) = .false.
-        read_rest_FBaccum(compglc) = .false.
-        read_rest_FBaccumAOflux    = .false.
-      endif
-    endif
-
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-
-  end subroutine Mediator_restart
-#endif
 
   !-----------------------------------------------------------------------------
 

--- a/src/drivers/nuopc/mediator/med_phases_history_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_history_mod.F90
@@ -46,13 +46,13 @@ module med_phases_history_mod
   integer, parameter            :: SecPerDay = 86400    ! Seconds per day
   type(ESMF_Alarm)              :: AlarmHist
 
-  public  :: med_phases_history
+  public  :: med_phases_history_write
 
 !-----------------------------------------------------------------------------
   contains
 !-----------------------------------------------------------------------------
 
-  subroutine med_phases_history(gcomp, rc)
+  subroutine med_phases_history_write(gcomp, rc)
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -87,7 +87,7 @@ module med_phases_history_mod
     logical       :: alarmIsOn    ! generic alarm flag
     real(r8)      :: tbnds(2)     ! CF1.0 time bounds
     logical       :: whead,wdata  ! for writing restart/history cdf files
-    character(len=*), parameter :: subname='(med_phases_history)'
+    character(len=*), parameter :: subname='(med_phases_history_write)'
     !---------------------------------------
 
     if (dbug_flag > 5) then
@@ -148,7 +148,7 @@ module med_phases_history_mod
     call ESMF_ClockPrint(clock, options="currTime", preString="-------->"//trim(subname)//" mediating for: ", rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    timediff = currtime - reftime
+    timediff = nexttime - reftime
     call ESMF_TimeIntervalGet(timediff, d=day, s=sec, rc=rc)
     dayssince = day + sec/real(SecPerDay,R8)
 
@@ -251,6 +251,6 @@ module med_phases_history_mod
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
     endif
 
-  end subroutine med_phases_history
+  end subroutine med_phases_history_write
 
 end module med_phases_history_mod

--- a/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
@@ -178,31 +178,31 @@ contains
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_rain' , dataptr1, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        dataptr1(:) = dataptr1(:) * flux_epbalfact 
-       write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_rain by flux_epbalfact '
+       if (first_call) write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_rain by flux_epbalfact '
     end if
     if (shr_nuopc_methods_FB_FldChk(is_local%wrap%FBExp(compocn), 'Foxx_snow', rc=rc)) then
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_snow' , dataptr1, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        dataptr1(:) = dataptr1(:) * flux_epbalfact 
-       write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_snow by flux_epbalfact '
+       if (first_call) write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_snow by flux_epbalfact '
     end if
     if (shr_nuopc_methods_FB_FldChk(is_local%wrap%FBExp(compocn), 'Foxx_prec', rc=rc)) then
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_prec' , dataptr1, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        dataptr1(:) = dataptr1(:) * flux_epbalfact 
-       write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_prec by flux_epbalfact '
+       if (first_call) write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_prec by flux_epbalfact '
     end if
     if (shr_nuopc_methods_FB_FldChk(is_local%wrap%FBExp(compocn), 'Foxx_rofl', rc=rc)) then
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , dataptr1, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        dataptr1(:) = dataptr1(:) * flux_epbalfact 
-       write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_rofl by flux_epbalfact '
+       if (first_call) write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_rofl by flux_epbalfact '
     end if
     if (shr_nuopc_methods_FB_FldChk(is_local%wrap%FBExp(compocn), 'Foxx_rofi', rc=rc)) then
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , dataptr1, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        dataptr1(:) = dataptr1(:) * flux_epbalfact 
-       write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_rofi by flux_epbalfact '
+       if (first_call) write(logunit,'(a)')'(merge_to_ocn): Scaling Foxx_rofi by flux_epbalfact '
     end if
 
     !---------------

--- a/src/drivers/nuopc/mediator/med_phases_restart_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_restart_mod.F90
@@ -1,0 +1,451 @@
+module med_phases_restart_mod
+
+  !-----------------------------------------------------------------------------
+  ! Mediator Phases
+  !-----------------------------------------------------------------------------
+
+  use ESMF
+  use NUOPC
+  use shr_kind_mod            , only : IN=>SHR_KIND_IN, R8=>SHR_KIND_R8
+  use shr_kind_mod            , only : CL=>SHR_KIND_CL, CS=>SHR_KIND_CS
+  use esmFlds                 , only : compatm, complnd, compocn, compice, comprof, compglc
+  use esmFlds                 , only : ncomps, compname 
+  use esmFlds                 , only : fldListFr, fldListTo
+  use esmFlds                 , only : fldListMed_aoflux_a, fldListMed_aoflux_o
+  use esmFlds                 , only : flds_scalar_name, flds_scalar_num
+  use esmFlds                 , only : flds_scalar_index_nx, flds_scalar_index_ny
+  use shr_nuopc_methods_mod   , only : shr_nuopc_methods_ChkErr
+  use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_reset
+  use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_diagnose
+  use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_GetFldPtr
+  use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_accum
+  use shr_nuopc_methods_mod   , only : shr_nuopc_methods_State_GetScalar
+  use shr_cal_mod             , only : shr_cal_noleap, shr_cal_gregorian
+  use shr_cal_mod             , only : shr_cal_ymd2date
+  use shr_file_mod            , only : shr_file_getUnit, shr_file_freeUnit
+  use shr_mpi_mod             , only : shr_mpi_bcast
+  use seq_timemgr_mod         , only : seq_timemgr_AlarmIsOn, seq_timemgr_EClockPrint
+  use seq_timemgr_mod         , only : seq_timemgr_AlarmSetOff, seq_timemgr_alarm_restart
+  use med_constants_mod       , only : med_constants_dbug_flag
+  use med_constants_mod       , only : med_constants_czero
+  use med_infodata_mod        , only : med_infodata, med_infodata_GetData
+  use med_merge_mod           , only : med_merge_auto
+  use med_map_mod             , only : med_map_FB_Regrid_Norm 
+  use med_internalstate_mod   , only : InternalState
+  use med_io_mod              , only : med_io_write, med_io_wopen, med_io_enddef
+  use med_io_mod              , only : med_io_close, med_io_date2yyyymmdd
+  use med_io_mod              , only : med_io_sec2hms, med_io_read
+
+  implicit none
+  private
+
+  integer           , parameter :: dbug_flag = med_constants_dbug_flag
+  real(ESMF_KIND_R8), parameter :: czero     = med_constants_czero
+  character(*)      , parameter :: u_FILE_u  = __FILE__
+  character(len=ESMF_MAXSTR)    :: tmpstr
+  integer                       :: dbrc
+  integer, parameter            :: SecPerDay = 86400    ! Seconds per day
+  character(len=*)  , parameter :: sp_str = 'str_undefined'
+
+  public  :: med_phases_restart_read
+  public  :: med_phases_restart_write
+
+!-----------------------------------------------------------------------------
+  contains
+!-----------------------------------------------------------------------------
+
+  subroutine med_phases_restart_write(gcomp, rc)
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! Carry out fast accumulation for the ocean
+
+    ! local variables
+    type(ESMF_VM)               :: vm
+    type(ESMF_Clock)            :: clock
+    type(ESMF_Time)             :: currtime, reftime, starttime, nexttime
+    type(ESMF_TimeInterval)     :: timediff       ! Used to calculate curr_time
+    type(ESMF_CalKind_Flag)     :: calkindflag
+    character(len=64)           :: currtimestr, nexttimestr
+    type(InternalState)         :: is_local
+    integer                     :: i,j,m,n,n1,ncnt
+    integer(IN)   :: curr_ymd     ! Current date YYYYMMDD
+    integer(IN)   :: curr_tod     ! Current time-of-day (s)
+    integer(IN)   :: start_ymd    ! Starting date YYYYMMDD
+    integer(IN)   :: start_tod    ! Starting time-of-day (s)
+    integer(IN)   :: ref_ymd      ! Reference date YYYYMMDD
+    integer(IN)   :: ref_tod      ! Reference time-of-day (s)
+    integer(IN)   :: next_ymd     ! Starting date YYYYMMDD
+    integer(IN)   :: next_tod     ! Starting time-of-day (s)
+    integer(IN)   :: nx,ny        ! global grid size
+    integer(IN)   :: yr,mon,day,sec ! time units
+    real(r8)      :: rval         ! real tmp value
+    real(r8)      :: dayssince    ! Time interval since reference time
+    integer(IN)   :: fk           ! index
+    integer(IN)   :: unitn        ! unit number
+    integer(IN)   :: iam,mpicom   ! vm stuff
+    character(CL) :: time_units   ! units of time variable
+    character(CL) :: calendar     ! calendar type
+    character(CL) :: case_name    ! case name
+    character(CL) :: restart_file ! Local path to restart filename
+    character(CL) :: restart_pfile! Local path to restart pointer filename
+    character(CS) :: cpl_inst_tag ! instance tag
+    character(CL) :: cvalue       ! attribute string
+    character(CL) :: freq_option  ! freq_option setting (ndays, nsteps, etc)
+    integer(IN)   :: freq_n       ! freq_n setting relative to freq_option
+    logical       :: alarmIsOn    ! generic alarm flag
+    real(r8)      :: tbnds(2)     ! CF1.0 time bounds
+    logical       :: whead,wdata  ! for writing restart/restart cdf files
+    character(len=*), parameter :: subname='(med_phases_restart_write)'
+    !---------------------------------------
+
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
+    endif
+    rc = ESMF_SUCCESS
+
+    !---------------------------------------
+    ! --- Get the internal state
+    !---------------------------------------
+
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMGet(vm, localPet=iam, mpiCommunicator=mpicom, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call NUOPC_CompAttributeGet(gcomp, name='case_name', value=case_name, rc=rc)
+    cpl_inst_tag = ''
+
+    !---------------------------------------
+    ! --- Get the clock info
+    !---------------------------------------
+
+    call ESMF_GridCompGet(gcomp, clock=clock)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !---------------------------------------
+    ! --- Restart Alarm
+    !---------------------------------------
+
+    alarmIsOn = seq_timemgr_alarmIsOn(clock, seq_timemgr_alarm_restart, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call seq_timemgr_AlarmSetOff(clock, seq_timemgr_alarm_restart, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call seq_timemgr_EClockPrint(clock)
+
+    if (alarmIsOn) then
+
+       call ESMF_ClockGet(clock, currtime=currtime, reftime=reftime, starttime=starttime, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call ESMF_ClockGetNextTime(clock, nextTime=nexttime, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call ESMF_ClockGet(clock, calkindflag=calkindflag, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (calkindflag == ESMF_CALKIND_GREGORIAN) then
+         calendar = shr_cal_gregorian
+       elseif (calkindflag == ESMF_CALKIND_NOLEAP) then
+         calendar = shr_cal_noleap
+       else
+         call ESMF_LogWrite(trim(subname)//' ERROR: calendar not supported', ESMF_LOGMSG_ERROR, rc=dbrc)
+         rc=ESMF_Failure
+         return
+       endif
+
+       call ESMF_TimeGet(currtime,yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       write(currtimestr,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') yr,'-',mon,'-',day,'-',sec
+       if (dbug_flag > 1) then
+          call ESMF_LogWrite(trim(subname)//": currtime = "//trim(currtimestr), ESMF_LOGMSG_INFO, rc=dbrc)
+       endif
+
+       call ESMF_TimeGet(nexttime,yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       write(nexttimestr,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') yr,'-',mon,'-',day,'-',sec
+       if (dbug_flag > 1) then
+          call ESMF_LogWrite(trim(subname)//": nexttime = "//trim(nexttimestr), ESMF_LOGMSG_INFO, rc=dbrc)
+       endif
+
+       call ESMF_ClockPrint(clock, options="currTime", preString="-------->"//trim(subname)//" mediating for: ", rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       timediff = nexttime - reftime
+       call ESMF_TimeIntervalGet(timediff, d=day, s=sec, rc=rc)
+       dayssince = day + sec/real(SecPerDay,R8)
+
+       call ESMF_TimeGet(reftime, yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+       call shr_cal_ymd2date(yr,mon,day,start_ymd)
+       start_tod = sec
+       time_units = 'days since ' &
+          // trim(med_io_date2yyyymmdd(start_ymd)) // ' ' // med_io_sec2hms(start_tod)
+
+       call ESMF_TimeGet(nexttime, yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+       call shr_cal_ymd2date(yr,mon,day,next_ymd)
+       next_tod = sec
+
+       call ESMF_TimeGet(reftime, yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+       call shr_cal_ymd2date(yr,mon,day,ref_ymd)
+       ref_tod = sec
+
+       call ESMF_TimeGet(currtime, yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+       call shr_cal_ymd2date(yr,mon,day,curr_ymd)
+       curr_tod = sec
+
+       !---------------------------------------
+       ! --- Restart File
+       ! Use nexttimestr rather than currtimestr here since that is the time at the end of 
+       ! the timestep and is preferred for restart file names
+       !---------------------------------------
+
+       write(restart_file,"(6a)") &
+!         trim(case_name), '.cpl',trim(cpl_inst_tag),'.r.', trim(currtimestr),'.nc'
+          trim(case_name), '.cpl',trim(cpl_inst_tag),'.r.', trim(nexttimestr),'.nc'
+
+       if (iam == 0) then
+          call NUOPC_CompAttributeGet(gcomp, name='restart_pfile', value=restart_pfile, rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+          call ESMF_LogWrite(trim(subname)//" write rpointer file = "//trim(restart_pfile), ESMF_LOGMSG_INFO, rc=dbrc)
+          unitn = shr_file_getUnit()
+          open(unitn, file=restart_pfile, form='FORMATTED')
+          write(unitn,'(a)') trim(restart_file)
+          close(unitn)
+          call shr_file_freeUnit( unitn )
+       endif
+
+       call ESMF_LogWrite(trim(subname)//": write "//trim(restart_file), ESMF_LOGMSG_INFO, rc=dbrc)
+       call med_io_wopen(restart_file,clobber=.true.)
+       do m = 1,2
+          whead=.false.
+          wdata=.false.
+          if (m == 1) then
+             whead=.true.
+          elseif (m == 2) then
+             wdata=.true.
+             call med_io_enddef(restart_file)
+          endif
+
+          tbnds = dayssince
+          !------- tcx nov 2011 tbnds of same values causes problems in ferret                  
+          call ESMF_LogWrite(trim(subname)//": time "//trim(time_units), ESMF_LOGMSG_INFO, rc=dbrc)
+          if (tbnds(1) >= tbnds(2)) then
+             call med_io_write(restart_file,&
+                  time_units=time_units, time_cal=calendar, time_val=dayssince, &
+                  whead=whead, wdata=wdata)
+          else
+             call med_io_write(restart_file, &
+                  time_units=time_units, time_cal=calendar, time_val=dayssince, &
+                  whead=whead, wdata=wdata, tbnds=tbnds)
+          endif
+
+          ! tcraig, write out next ymd/tod in place of curr ymd/tod because the restart represents 
+          ! the time at end of the current timestep and that is where we want to start the next run.
+          call med_io_write(restart_file, start_ymd, 'seq_timemgr_start_ymd', whead=whead, wdata=wdata)
+          call med_io_write(restart_file, start_tod, 'seq_timemgr_start_tod', whead=whead, wdata=wdata)
+          call med_io_write(restart_file, ref_ymd  , 'seq_timemgr_ref_ymd'  , whead=whead, wdata=wdata)
+          call med_io_write(restart_file, ref_tod  , 'seq_timemgr_ref_tod'  , whead=whead, wdata=wdata)
+          call med_io_write(restart_file, next_ymd , 'seq_timemgr_curr_ymd' , whead=whead, wdata=wdata)
+          call med_io_write(restart_file, next_tod , 'seq_timemgr_curr_tod' , whead=whead, wdata=wdata)
+
+          call med_io_write(restart_file, is_local%wrap%FBExpAccumCnt, dname='ExpAccumCnt', &
+             whead=whead, wdata=wdata)
+          !if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+ 
+          do n = 1,ncomps
+             if (is_local%wrap%comp_present(n)) then
+                if (ESMF_FieldBundleIsCreated(is_local%wrap%FBimp(n,n),rc=rc)) then
+                   call med_infodata_GetData(med_infodata, ncomp=n, nx=nx, ny=ny)
+                   !write(tmpstr,*) subname,' nx,ny = ',trim(compname(n)),nx,ny
+                   !call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
+                   call med_io_write(restart_file, is_local%wrap%FBimp(n,n), &
+                       nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'Imp', rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+                endif
+                if (ESMF_FieldBundleIsCreated(is_local%wrap%FBfrac(n),rc=rc)) then
+                   call med_infodata_GetData(med_infodata, ncomp=n, nx=nx, ny=ny)
+                   !write(tmpstr,*) subname,' nx,ny = ',trim(compname(n)),nx,ny
+                   !call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
+                   call med_io_write(restart_file, is_local%wrap%FBfrac(n), &
+                       nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'Frac', rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+                endif
+                if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccum(n),rc=rc)) then
+                   call med_infodata_GetData(med_infodata, ncomp=n, nx=nx, ny=ny)
+                   !write(tmpstr,*) subname,' nx,ny = ',trim(compname(n)),nx,ny
+                   !call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
+                   call med_io_write(restart_file, is_local%wrap%FBExpAccum(n), &
+                       nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'ExpAccum', rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+                endif
+             endif
+          enddo
+
+       enddo
+       call med_io_close(restart_file)
+
+    endif
+
+    !---------------------------------------
+    !--- clean up
+    !---------------------------------------
+
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+    endif
+
+  end subroutine med_phases_restart_write
+
+!-----------------------------------------------------------------------------
+
+  subroutine med_phases_restart_read(gcomp, rc)
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! Carry out fast accumulation for the ocean
+
+    ! local variables
+    type(ESMF_VM)       :: vm
+    type(ESMF_Clock)    :: clock
+    type(ESMF_Time)     :: currtime
+    character(len=64)   :: currtimestr
+    type(InternalState) :: is_local
+    integer       :: i,j,m,n,n1,ncnt
+    integer(IN)   :: ierr, unitn
+    integer(IN)   :: yr,mon,day,sec ! time units
+    integer(IN)   :: iam,mpicom   ! vm stuff
+    character(CL) :: case_name    ! case name
+    character(CL) :: restart_file ! Local path to restart filename
+    character(CL) :: restart_pfile! Local path to restart pointer filename
+    character(CS) :: cpl_inst_tag ! instance tag
+    character(len=*), parameter :: subname='(med_phases_restart_read)'
+    !---------------------------------------
+
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
+    endif
+    rc = ESMF_SUCCESS
+
+    !---------------------------------------
+    ! --- Get the internal state
+    !---------------------------------------
+
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMGet(vm, localPet=iam, mpiCommunicator=mpicom, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call NUOPC_CompAttributeGet(gcomp, name='case_name', value=case_name, rc=rc)
+    cpl_inst_tag = ''
+
+    !---------------------------------------
+    ! --- Get the clock info
+    !---------------------------------------
+
+    call ESMF_GridCompGet(gcomp, clock=clock)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_ClockGet(clock, currtime=currtime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_TimeGet(currtime,yy=yr, mm=mon, dd=day, s=sec, rc=dbrc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    write(currtimestr,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') yr,'-',mon,'-',day,'-',sec
+    if (dbug_flag > 1) then
+       call ESMF_LogWrite(trim(subname)//": currtime = "//trim(currtimestr), ESMF_LOGMSG_INFO, rc=dbrc)
+    endif
+
+    call ESMF_ClockPrint(clock, options="currTime", preString="-------->"//trim(subname)//" mediating for: ", rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !---------------------------------------
+    ! --- Restart File
+    !---------------------------------------
+
+    ! Error check on restart_pfile                                                                                                      
+    call NUOPC_CompAttributeGet(gcomp, name="restart_pfile", value=restart_pfile, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if ( len_trim(restart_pfile) == 0 ) then
+       call ESMF_LogWrite(trim(subname)//' ERROR restart_pfile must be set', ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__, rc=rc)
+       rc = ESMF_FAILURE
+       return
+    end if
+
+    if (iam == 0) then
+       call NUOPC_CompAttributeGet(gcomp, name='restart_file', value=restart_file, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       !--- read rpointer if restart_file is set to sp_str ---                                                                       
+
+       if (trim(restart_file) == trim(sp_str)) then
+          call NUOPC_CompAttributeGet(gcomp, name='restart_pfile', value=restart_file, rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+          unitn = shr_file_getUnit()
+          call ESMF_LogWrite(trim(subname)//" read rpointer file = "//trim(restart_pfile), ESMF_LOGMSG_INFO, rc=dbrc)
+          open(unitn, file=restart_pfile, form='FORMATTED', status='old',iostat=ierr)
+          if (ierr < 0) then
+             call ESMF_LogWrite(trim(subname)//' rpointer file open returns error', ESMF_LOGMSG_INFO, rc=dbrc)
+             rc=ESMF_Failure
+             return
+          end if
+          read(unitn,'(a)', iostat=ierr) restart_file
+          if (ierr < 0) then
+             call ESMF_LogWrite(trim(subname)//' rpointer file read returns error', ESMF_LOGMSG_INFO, rc=dbrc)
+             rc=ESMF_Failure
+             return
+          end if
+          close(unitn)
+          call shr_file_freeUnit( unitn )
+          call ESMF_LogWrite(trim(subname)//' restart file from rpointer = '//trim(restart_file), ESMF_LOGMSG_INFO, rc=dbrc)
+       endif
+    endif
+    call shr_mpi_bcast(restart_file, mpicom)
+
+    call ESMF_LogWrite(trim(subname)//": read "//trim(restart_file), ESMF_LOGMSG_INFO, rc=dbrc)
+ 
+    call med_io_read(restart_file, is_local%wrap%FBExpAccumCnt, dname='ExpAccumCnt')
+
+    do n = 1,ncomps
+       if (is_local%wrap%comp_present(n)) then
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBimp(n,n),rc=rc)) then
+             call med_io_read(restart_file, is_local%wrap%FBimp(n,n), &
+                 pre=trim(compname(n))//'Imp', rc=rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBfrac(n),rc=rc)) then
+             call med_io_read(restart_file, is_local%wrap%FBfrac(n), &
+                 pre=trim(compname(n))//'Frac', rc=rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccum(n),rc=rc)) then
+             call med_io_read(restart_file, is_local%wrap%FBExpAccum(n), &
+                 pre=trim(compname(n))//'ExpAccum', rc=rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
+       endif
+    enddo
+
+    !---------------------------------------
+    !--- clean up
+    !---------------------------------------
+
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+    endif
+
+  end subroutine med_phases_restart_read
+
+!-----------------------------------------------------------------------------
+
+end module med_phases_restart_mod


### PR DESCRIPTION
Add mediator restart capability.  

Also update clocks, alarms, and filenames for consistency.  med 
history and restarts are set by the _OPTION and _N settings in 
env_run.xml.   

The model advance setRunClock has been specialized so it syncs with 
the driver clock, advances one coupling period (to trigger alarms), then 
resets the clock to the start of the coupling period.  The clock is officially
advanced by the generic NUOPC AdvanceClock method.  

The filenames are named based on the stop time of the current
coupling period.  This should be done consistently in all components.
This has only been modified and validated with data models.  Dead
models do not write history or restart files, so there is not a problem.
But prognostic models will probably need to have their caps setup 
the same way.  

med_phases_restart_write was added to the run sequence and 
med_phases_history was renamed to med_phases_history_write.

Added ability to have driver restarts separate from mediator restarts
in the attributes.  Current, the driver uses the mediator restarts.
Updated how the driver reads in the restart time.  (The mediator
writes that time).

Updated use of "currentymd, currenttod" when it is really was 
"nextymd, nexttod".  also use "target_ymd, target_tod" in run method 
to provide further clarification.

Logic associated with checking rpointer file and restart files in the
data models was improved.

Removed some excessive print statements.

Updated implementation associated with checking restart alarms in 
components.


Test suite: SMS_Vnuopc_Ld1.T31_g37_rx1.A.cheyenne_intel
  verified bit-for-bit restart with this case.  The ERS test failed in the scripts, so was not used for testing.
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing] bit for bit

Fixes [CIME Github issue #] #5 

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: 
