### PR TITLE
New advertise/realize implementation in datm

### DIFF
--- a/src/components/data_comps/datm/datm_comp_mod.F90
+++ b/src/components/data_comps/datm/datm_comp_mod.F90
@@ -208,7 +208,7 @@ CONTAINS
   !===============================================================================
 
   subroutine datm_comp_init(Eclock, x2a, a2x, &
-       seq_flds_x2a_fields, seq_flds_a2x_fields, &
+       x2a_fields, a2x_fields, &
        SDATM, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, inst_name, logunit, read_restart, &
        scmMode, scmlat, scmlon, &
@@ -219,33 +219,34 @@ CONTAINS
 
     ! !INPUT/OUTPUT PARAMETERS:
     type(ESMF_Clock)       , intent(in)    :: EClock
-    type(mct_aVect)        , intent(inout) :: x2a, a2x
-    character(len=*)       , intent(in)    :: seq_flds_x2a_fields ! fields from mediator
-    character(len=*)       , intent(in)    :: seq_flds_a2x_fields ! fields to mediator
-    type(shr_strdata_type) , intent(inout) :: SDATM               ! model shr_strdata instance (output)
-    type(mct_gsMap)        , pointer       :: gsMap               ! model global sep map (output)
-    type(mct_gGrid)        , pointer       :: ggrid               ! model ggrid (output)
-    integer(IN)            , intent(in)    :: mpicom              ! mpi communicator
-    integer(IN)            , intent(in)    :: compid              ! mct comp id
-    integer(IN)            , intent(in)    :: my_task             ! my task in mpi communicator mpicom
-    integer(IN)            , intent(in)    :: master_task         ! task number of master task
-    character(len=*)       , intent(in)    :: inst_suffix         ! char string associated with instance
-    character(len=*)       , intent(in)    :: inst_name           ! fullname of current instance (ie. "lnd_0001")
-    integer(IN)            , intent(in)    :: logunit             ! logging unit number
-    logical                , intent(in)    :: read_restart        ! start from restart
-    logical                , intent(in)    :: scmMode             ! single column mode
-    real(R8)               , intent(in)    :: scmLat              ! single column lat
-    real(R8)               , intent(in)    :: scmLon              ! single column lon
-    real(R8)               , intent(in)    :: orbEccen            ! orb eccentricity (unit-less)
-    real(R8)               , intent(in)    :: orbMvelpp           ! orb moving vernal eq (radians)
-    real(R8)               , intent(in)    :: orbLambm0           ! orb mean long of perhelion (radians)
-    real(R8)               , intent(in)    :: orbObliqr           ! orb obliquity (radians)
-    character(len=*)       , intent(in)    :: calendar            ! calendar type
-    integer                , intent(in)    :: modeldt             ! model time step
-    integer                , intent(in)    :: CurrentYMD          ! model date
-    integer                , intent(in)    :: CurrentTOD          ! model sec into model date
-    integer                , intent(in)    :: CurrentMON          ! model month
-    logical                , intent(in)    :: atm_prognostic      ! if true, need x2a data
+    type(mct_aVect)        , intent(inout) :: x2a
+    type(mct_aVect)        , intent(inout) :: a2x
+    character(len=*)       , intent(in)    :: x2a_fields     ! fields from mediator
+    character(len=*)       , intent(in)    :: a2x_fields     ! fields to mediator
+    type(shr_strdata_type) , intent(inout) :: SDATM          ! model shr_strdata instance (output)
+    type(mct_gsMap)        , pointer       :: gsMap          ! model global sep map (output)
+    type(mct_gGrid)        , pointer       :: ggrid          ! model ggrid (output)
+    integer(IN)            , intent(in)    :: mpicom         ! mpi communicator
+    integer(IN)            , intent(in)    :: compid         ! mct comp id
+    integer(IN)            , intent(in)    :: my_task        ! my task in mpi communicator mpicom
+    integer(IN)            , intent(in)    :: master_task    ! task number of master task
+    character(len=*)       , intent(in)    :: inst_suffix    ! char string associated with instance
+    character(len=*)       , intent(in)    :: inst_name      ! fullname of current instance (ie. "lnd_0001")
+    integer(IN)            , intent(in)    :: logunit        ! logging unit number
+    logical                , intent(in)    :: read_restart   ! start from restart
+    logical                , intent(in)    :: scmMode        ! single column mode
+    real(R8)               , intent(in)    :: scmLat         ! single column lat
+    real(R8)               , intent(in)    :: scmLon         ! single column lon
+    real(R8)               , intent(in)    :: orbEccen       ! orb eccentricity (unit-less)
+    real(R8)               , intent(in)    :: orbMvelpp      ! orb moving vernal eq (radians)
+    real(R8)               , intent(in)    :: orbLambm0      ! orb mean long of perhelion (radians)
+    real(R8)               , intent(in)    :: orbObliqr      ! orb obliquity (radians)
+    character(len=*)       , intent(in)    :: calendar       ! calendar type
+    integer                , intent(in)    :: modeldt        ! model time step
+    integer                , intent(in)    :: CurrentYMD     ! model date
+    integer                , intent(in)    :: CurrentTOD     ! model sec into model date
+    integer                , intent(in)    :: CurrentMON     ! model month
+    logical                , intent(in)    :: atm_prognostic ! if true, need x2a data
 
     !--- local variables ---
     integer(IN)   :: n,k            ! generic counters
@@ -346,7 +347,7 @@ CONTAINS
     if (my_task == master_task) write(logunit,F00) 'allocate AVs'
     call shr_sys_flush(logunit)
 
-    call mct_aVect_init(a2x, rList=seq_flds_a2x_fields, lsize=lsize)
+    call mct_aVect_init(a2x, rList=a2x_fields, lsize=lsize)
     call mct_aVect_zero(a2x)
 
     kz    = mct_aVect_indexRA(a2x,'Sa_z')
@@ -383,7 +384,7 @@ CONTAINS
        ksl_HDO   = mct_aVect_indexRA(a2x,'Faxa_snowl_HDO')
     end if
 
-    call mct_aVect_init(x2a, rList=seq_flds_x2a_fields, lsize=lsize)
+    call mct_aVect_init(x2a, rList=x2a_fields, lsize=lsize)
     call mct_aVect_zero(x2a)
 
     if (atm_prognostic) then 

--- a/src/components/data_comps/datm/datm_comp_mod.F90
+++ b/src/components/data_comps/datm/datm_comp_mod.F90
@@ -256,7 +256,6 @@ CONTAINS
     integer(IN)   :: stepno      ! step number
     character(CL) :: calendar    ! calendar type
     character(CL) :: flds_strm
-    logical       :: write_restart
 
     !--- formats ---
     character(*), parameter :: F00   = "('(datm_comp_init) ',8a)"
@@ -571,12 +570,11 @@ CONTAINS
          orbLambm0=orbLambm0, &
          orbObliqr=orbObliqr, &
          nextsw_cday=nextsw_cday, &
-         write_restart=write_restart, &
+         write_restart=.false., &
          target_ymd=currentYMD, &
          target_tod=currentTOD)
     call t_adj_detailf(-2)
 
-    write_restart = .false.
     call t_stopf('DATM_INIT')
 
   end subroutine datm_comp_init

--- a/src/components/data_comps/datm/datm_comp_mod.F90
+++ b/src/components/data_comps/datm/datm_comp_mod.F90
@@ -74,7 +74,7 @@ module datm_comp_mod
   data   dTarc      / 0.49_R8, 0.06_R8,-0.73_R8,  -0.89_R8,-0.77_R8,-1.02_R8, &
                      -1.99_R8,-0.91_R8, 1.72_R8,   2.30_R8, 1.81_R8, 1.06_R8/
 
-  integer(IN) :: kz,ktopo,ku,kv,ktbot,kptem,kshum,kdens,kpbot,kpslv,klwdn
+  integer(IN) :: kz,ku,kv,ktbot,kptem,kshum,kdens,kpbot,kpslv,klwdn
   integer(IN) :: krc,krl,ksc,ksl,kswndr,kswndf,kswvdr,kswvdf,kswnet
   integer(IN) :: kanidr,kanidf,kavsdr,kavsdf
   integer(IN) :: stbot,swind,sz,spbot,sshum,stdew,srh,slwdn,sswdn,sswdndf,sswdndr
@@ -101,25 +101,15 @@ module datm_comp_mod
   real(R8), pointer    :: winddFactor(:)
   real(R8), pointer    :: qsatFactor(:)
 
-  integer(IN),parameter :: ktrans  = 77
+  integer(IN),parameter :: ktrans  = 41
 
   character(16),parameter  :: avofld(1:ktrans) = &
-       (/"Sa_z            ","Sa_topo         ", &
-       "Sa_u            ","Sa_v            ","Sa_tbot         ", &
+     (/"Sa_z            ","Sa_u            ","Sa_v            ","Sa_tbot         ", &
        "Sa_ptem         ","Sa_shum         ","Sa_dens         ","Sa_pbot         ", &
        "Sa_pslv         ","Faxa_lwdn       ","Faxa_rainc      ","Faxa_rainl      ", &
        "Faxa_snowc      ","Faxa_snowl      ","Faxa_swndr      ","Faxa_swvdr      ", &
        "Faxa_swndf      ","Faxa_swvdf      ","Faxa_swnet      ","Sa_co2prog      ", &
-       "Sa_co2diag      ","Faxa_bcphidry   ","Faxa_bcphodry   ","Faxa_bcphiwet   ", &
-       "Faxa_ocphidry   ","Faxa_ocphodry   ","Faxa_ocphiwet   ","Faxa_dstwet1    ", &
-       "Faxa_dstwet2    ","Faxa_dstwet3    ","Faxa_dstwet4    ","Faxa_dstdry1    ", &
-       "Faxa_dstdry2    ","Faxa_dstdry3    ","Faxa_dstdry4    ",                    &
-       "Sx_tref         ","Sx_qref         ","Sx_avsdr        ","Sx_anidr        ", &
-       "Sx_avsdf        ","Sx_anidf        ","Sx_t            ","So_t            ", &
-       "Sl_snowh        ","Sf_lfrac        ","Sf_ifrac        ","Sf_ofrac        ", &
-       "Faxx_taux       ","Faxx_tauy       ","Faxx_lat        ","Faxx_sen        ", &
-       "Faxx_lwup       ","Faxx_evap       ","Fall_fco2_lnd   ","Faoo_fco2_ocn   ", &
-       "Faoo_fdms_ocn   ",  &
+       "Sa_co2diag      ",
        ! add values for bias correction / anomaly forcing
        "Sa_precsf       ", &
        "Sa_prec_af      ","Sa_u_af         ","Sa_v_af         ","Sa_tbot_af      ",&
@@ -127,26 +117,16 @@ module datm_comp_mod
        ! isotopic forcing
        "Faxa_rainc_18O  ","Faxa_rainc_HDO  ","Faxa_rainl_18O  ","Faxa_rainl_HDO  ",&
        "Faxa_snowc_18O  ","Faxa_snowc_HDO  ","Faxa_snowl_18O  ","Faxa_snowl_HDO  ",&
-       "Sa_shum_16O     ","Sa_shum_18O     ","Sa_shum_HDO     " &
+       "Sa_shum_16O     ","Sa_shum_18O     ","Sa_shum_HDO     " 
        /)
 
   character(16),parameter  :: avifld(1:ktrans) = &
-       (/"z               ","topo            ", &
-       "u               ","v               ","tbot            ", &
+     (/"z               ","u               ","v               ","tbot            ", &
        "ptem            ","shum            ","dens            ","pbot            ", &
        "pslv            ","lwdn            ","rainc           ","rainl           ", &
        "snowc           ","snowl           ","swndr           ","swvdr           ", &
        "swndf           ","swvdf           ","swnet           ","co2prog         ", &
-       "co2diag         ","bcphidry        ","bcphodry        ","bcphiwet        ", &
-       "ocphidry        ","ocphodry        ","ocphiwet        ","dstwet1         ", &
-       "dstwet2         ","dstwet3         ","dstwet4         ","dstdry1         ", &
-       "dstdry2         ","dstdry3         ","dstdry4         ",                    &
-       "tref            ","qref            ","avsdr           ","anidr           ", &
-       "avsdf           ","anidf           ","ts              ","to              ", &
-       "snowhl          ","lfrac           ","ifrac           ","ofrac           ", &
-       "taux            ","tauy            ","lat             ","sen             ", &
-       "lwup            ","evap            ","co2lnd          ","co2ocn          ", &
-       "dms             ", &
+       "co2diag         ",
        ! add values for bias correction / anomaly forcing (add Sa_precsf for precip scale factor)
        "precsf          ", &
        "prec_af         ","u_af            ","v_af            ","tbot_af         ", &
@@ -154,7 +134,7 @@ module datm_comp_mod
        ! isotopic forcing
        "rainc_18O       ","rainc_HDO       ","rainl_18O       ","rainl_HDO       ", &
        "snowc_18O       ","snowc_HDO       ","snowl_18O       ","snowl_HDO       ", &
-       "shum_16O        ","shum_18O        ","shum_HDO        " &
+       "shum_16O        ","shum_18O        ","shum_HDO        " 
        /)
 
   ! The stofld and stifld lists are used for fields that are read but not passed to the
@@ -165,7 +145,7 @@ module datm_comp_mod
   integer(IN),parameter :: ktranss = 33
 
   character(16),parameter  :: stofld(1:ktranss) = &
-       (/"strm_tbot       ","strm_wind       ","strm_z          ","strm_pbot       ", &
+     (/"strm_tbot       ","strm_wind       ","strm_z          ","strm_pbot       ", &
        "strm_shum       ","strm_tdew       ","strm_rh         ","strm_lwdn       ", &
        "strm_swdn       ","strm_swdndf     ","strm_swdndr     ","strm_precc      ", &
        "strm_precl      ","strm_precn      ","strm_co2prog    ","strm_co2diag    ", &
@@ -179,7 +159,7 @@ module datm_comp_mod
        /)
 
   character(16),parameter  :: stifld(1:ktranss) = &
-       (/"tbot            ","wind            ","z               ","pbot            ", &
+     (/"tbot            ","wind            ","z               ","pbot            ", &
        "shum            ","tdew            ","rh              ","lwdn            ", &
        "swdn            ","swdndf          ","swdndr          ","precc           ", &
        "precl           ","precn           ","co2prog         ","co2diag         ", &
@@ -357,7 +337,6 @@ CONTAINS
     call mct_aVect_zero(a2x)
 
     kz    = mct_aVect_indexRA(a2x,'Sa_z')
-    ktopo = mct_aVect_indexRA(a2x,'Sa_topo')
     ku    = mct_aVect_indexRA(a2x,'Sa_u')
     kv    = mct_aVect_indexRA(a2x,'Sa_v')
     ktbot = mct_aVect_indexRA(a2x,'Sa_tbot')
@@ -744,9 +723,9 @@ CONTAINS
           uprime    = a2x%rAttr(ku,n)*windFactor(n)
           vprime    = a2x%rAttr(kv,n)*windFactor(n)
           a2x%rAttr(ku,n) = uprime*cos(winddFactor(n)*degtorad)- &
-               vprime*sin(winddFactor(n)*degtorad)
+                            vprime*sin(winddFactor(n)*degtorad)
           a2x%rAttr(kv,n) = uprime*sin(winddFactor(n)*degtorad)+ &
-               vprime*cos(winddFactor(n)*degtorad)
+                            vprime*cos(winddFactor(n)*degtorad)
 
           !--- density, tbot, & pslv taken directly from input stream, set pbot ---
           a2x%rAttr(kpbot,n) = a2x%rAttr(kpslv,n)
@@ -1011,9 +990,9 @@ CONTAINS
              a2x%rAttr(kswnet,n) = 0.0_R8
           else
              a2x%rAttr(kswnet,n) = (1.0_R8-x2a%rAttr(kanidr,n))*a2x%rAttr(kswndr,n) + &
-                  (1.0_R8-x2a%rAttr(kavsdr,n))*a2x%rAttr(kswvdr,n) + &
-                  (1.0_R8-x2a%rAttr(kanidf,n))*a2x%rAttr(kswndf,n) + &
-                  (1.0_R8-x2a%rAttr(kavsdf,n))*a2x%rAttr(kswvdf,n)
+                                   (1.0_R8-x2a%rAttr(kavsdr,n))*a2x%rAttr(kswvdr,n) + &
+                                   (1.0_R8-x2a%rAttr(kanidf,n))*a2x%rAttr(kswndf,n) + &
+                                   (1.0_R8-x2a%rAttr(kavsdf,n))*a2x%rAttr(kswvdf,n)
           endif
 
           !--- rain and snow ---
@@ -1134,7 +1113,6 @@ CONTAINS
     if (dbug > 1 .and. my_task == master_task) then
        do n = 1,lsize
           write(logunit,F01)'export: ymd,tod,n,Sa_z       = ',target_ymd, target_tod, n,a2x%rAttr(kz,n)
-          write(logunit,F01)'export: ymd,tod,n,Sa_topo    = ',target_ymd, target_tod, n,a2x%rAttr(ktopo,n)
           write(logunit,F01)'export: ymd,tod,n,Sa_u       = ',target_ymd, target_tod, n,a2x%rAttr(ku,n)
           write(logunit,F01)'export: ymd,tod,n,Sa_v       = ',target_ymd, target_tod, n,a2x%rAttr(kv,n)
           write(logunit,F01)'export: ymd,tod,n,Sa_tbot    = ',target_ymd, target_tod, n,a2x%rAttr(ktbot,n)

--- a/src/components/data_comps/datm/datm_shr_mod.F90
+++ b/src/components/data_comps/datm/datm_shr_mod.F90
@@ -197,11 +197,11 @@ CONTAINS
     implicit none
 
     ! !INPUT/OUTPUT PARAMETERS:
-    integer(IN), intent(IN)    :: ymd
-    integer(IN), intent(IN)    :: tod
-    integer(IN), intent(IN)    :: stepno
-    integer(IN), intent(IN)    :: dtime
-    integer(IN), intent(IN)    :: iradsw
+    integer(IN), intent(in)    :: ymd
+    integer(IN), intent(in)    :: tod
+    integer(IN), intent(in)    :: stepno
+    integer(IN), intent(in)    :: dtime
+    integer(IN), intent(in)    :: iradsw
     character(*),intent(in)    :: calendar
 
     !----- local -----
@@ -421,8 +421,8 @@ CONTAINS
     deallocate(start,length)
     lsizei = mct_gsmap_lsize(gsmapi,mpicom)
     lsizeo = mct_gsmap_lsize(gsmapo,mpicom)
-    call mct_gGrid_init(GGrid=gGridi, CoordChars=trim(shr_flds_dom_coord), &
-         OtherChars=trim(shr_flds_dom_other), lsize=lsizei )
+    call mct_gGrid_init(GGrid=gGridi, CoordChars=trim(shr_flds_dom_coord), OtherChars=trim(shr_flds_dom_other), &
+         lsize=lsizei )
     call mct_aVect_init(avi,rList="wind:windd:qsat",lsize=lsizei)
     avi%rAttr = SHR_CONST_SPVAL
 

--- a/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
@@ -4,8 +4,7 @@ module atm_comp_nuopc
   ! This is the NUOPC cap for DATM
   !----------------------------------------------------------------------------
 
-  use shr_kind_mod          , only : CXX => shr_kind_CXX
-  use med_constants_mod     , only : IN, R8, I8
+  use med_constants_mod     , only : IN, R8, I8, CXX
   use shr_log_mod           , only : shr_log_Unit
   use shr_cal_mod           , only : shr_cal_ymd2date, shr_cal_noleap, shr_cal_gregorian
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
@@ -57,6 +56,8 @@ module atm_comp_nuopc
   private :: ModelAdvance
   private :: ModelSetRunClock
   private :: ModelFinalize
+  private :: flds_list_add
+  private :: flds_list_realize
 
   !--------------------------------------------------------------------------
   ! Private module data

--- a/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
@@ -11,7 +11,6 @@ module atm_comp_nuopc
   use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
   use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
   use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use esmFlds               , only : fldListFr, fldListTo, compatm, compname
   use esmFlds               , only : flds_scalar_name
   use esmFlds               , only : flds_scalar_num
   use esmFlds               , only : flds_scalar_index_nx
@@ -35,10 +34,10 @@ module atm_comp_nuopc
   use ESMF
   use NUOPC
   use NUOPC_Model, &
-    model_routine_SS      => SetServices, &
-    model_label_Advance   => label_Advance, &
+    model_routine_SS        => SetServices, &
+    model_label_Advance     => label_Advance, &
     model_label_SetRunClock => label_SetRunClock, &
-    model_label_Finalize  => label_Finalize
+    model_label_Finalize    => label_Finalize
 
   use datm_shr_mod , only: datm_shr_read_namelists
   use datm_shr_mod , only: iradsw         ! namelist input
@@ -62,6 +61,16 @@ module atm_comp_nuopc
   !--------------------------------------------------------------------------
   ! Private module data
   !--------------------------------------------------------------------------
+
+  type fld_list_type
+    character(len=128) :: stdname
+  end type fld_list_type
+
+  integer,parameter          :: fldsMax = 100
+  integer                    :: fldsToAtm_num = 0
+  integer                    :: fldsFrAtm_num = 0
+  type (fld_list_type)       :: fldsToAtm(fldsMax)
+  type (fld_list_type)       :: fldsFrAtm(fldsMax)
 
   character(len=80)          :: myModelName = 'atm'       ! user defined model name
   type(shr_strdata_type)     :: SDATM
@@ -89,8 +98,8 @@ module atm_comp_nuopc
   integer, parameter         :: dbug = 10
   character(len=*),parameter :: grid_option = "mesh"      ! grid_de, grid_arb, grid_reg, mesh
   character(len=80)          :: calendar                  ! calendar name
-  character(CXX)             :: flds_a2x = ''
-  character(CXX)             :: flds_x2a = ''
+  character(len=CXX)         :: flds_a2x = ''
+  character(len=CXX)         :: flds_x2a = ''
 
   !----- formats -----
   character(*),parameter :: modName =  "(atm_comp_nuopc)"
@@ -192,6 +201,10 @@ module atm_comp_nuopc
     logical            :: isPresent
     character(len=512) :: diro
     character(len=512) :: logfile
+    logical            :: flds_co2a  ! use case
+    logical            :: flds_co2b  ! use case
+    logical            :: flds_co2c  ! use case
+    logical            :: flds_wiso  ! use case
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -271,41 +284,112 @@ module atm_comp_nuopc
     end if
 
     !--------------------------------
-    ! create import and export field list needed by data models
+    ! determine necessary toggles for below
     !--------------------------------
 
-    call shr_nuopc_fldList_Concat(fldListFr(compatm), fldListTo(compatm), flds_a2x, flds_x2a, flds_scalar_name)
+    call NUOPC_CompAttributeGet(gcomp, name='flds_co2a', value=cvalue, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_co2a
+    call ESMF_LogWrite('flds_co2a = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
+
+    call NUOPC_CompAttributeGet(gcomp, name='flds_co2b', value=cvalue, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_co2b
+    call ESMF_LogWrite('flds_co2b = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
+
+    call NUOPC_CompAttributeGet(gcomp, name='flds_co2c', value=cvalue, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_co2c
+    call ESMF_LogWrite('flds_co2c = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
+
+    call NUOPC_CompAttributeGet(gcomp, name='flds_wiso', value=cvalue, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_wiso
+    call ESMF_LogWrite('flds_wiso = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
 
     !--------------------------------
     ! advertise import and export fields
     !--------------------------------
 
-    ! First deactivate fldListTo(compatm) if atm_prognostic is .false.
-    if (.not. atm_prognostic) then
-       call shr_nuopc_fldList_Deactivate(fldListTo(compatm), flds_scalar_name)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, trim(flds_scalar_name)) 
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_topo'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_z'       , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_u'       , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_v'       , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_tbot'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_ptem'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_shum'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_pbot'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_dens'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_pslv'    , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_rainc' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_rainl' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_snowc' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_snowl' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_lwdn'  , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swndr' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swvdr' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swndf' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swvdf' , flds_concat=flds_a2x)
+    call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swnet' , flds_concat=flds_a2x)  ! only diagnostic
+    if (presaero) then
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_bcphidry' , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_bcphodry' , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_bcphiwet' , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_ocphidry' , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_ocphodry' , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_ocphiwet' , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstwet1'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstwet2'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstwet3'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstwet4'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstdry1'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstdry2'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstdry3'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstdry4'  , flds_concat=flds_a2x)
+    end if
+    if (flds_co2a .or. flds_co2b .or. flds_co2c) then
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_co2prog'  , flds_concat=flds_a2x)
+       call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_co2diag'  , flds_concat=flds_a2x)
     end if
 
-    nflds = shr_nuopc_fldList_Getnumflds(fldListFr(compatm))
-    do n = 1,nflds
-       call shr_nuopc_fldList_Getfldinfo(fldListFr(compatm), n, activefld, stdname, shortname)
-       if (activefld) then
-          call NUOPC_Advertise(exportState, standardName=stdname, shortname=shortname, name=shortname, &
-               TransferOfferGeomObject='will provide', rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_LogWrite(subname//':Fr_'//trim(compname(compatm))//': '//trim(shortname), ESMF_LOGMSG_INFO)
-       end if
-    end do
+    call fld_list_add(fldsToAtm_num, fldsToAtm, trim(flds_scalar_name))
+    if (atm_prognostic) then
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_anidr'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_avsdf'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_anidf'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_avsdr'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sl_lfrac'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Si_ifrac'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'So_ofrac'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_tref'   , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_qref'   , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_t'      , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'So_t'      , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sl_fv'     , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sl_ram1'   , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sl_snowh'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Si_snowh'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'So_ssq'    , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'So_re'     , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_u10'    , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_taux' , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_tauy' , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_lat'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_sen'  , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_lwup' , flds_concat=flds_x2a)
+       call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_evap' , flds_concat=flds_x2a)
+    end if
 
-    nflds = shr_nuopc_fldList_Getnumflds(fldListTo(compatm))
-    do n = 1,nflds
-       call shr_nuopc_fldList_Getfldinfo(fldListTo(compatm), n, activefld, stdname, shortname)
-       if (activefld) then
-          call NUOPC_Advertise(importState, standardName=stdname, shortname=shortname, name=shortname, &
-               TransferOfferGeomObject='will provide', rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_LogWrite(subname//':To_'//trim(compname(compatm))//': '//trim(shortname), ESMF_LOGMSG_INFO)
-       end if
-    end do
+    ! Now advertise these fields
+    do n = 1,fldsFrAtm_num
+      call NUOPC_Advertise(exportState, standardName=fldsFrAtm(n)%stdname, TransferOfferGeomObject='will provide', rc=rc)
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    enddo
+    do n = 1,fldsToAtm_num
+      call NUOPC_Advertise(importState, standardName=fldsToAtm(n)%stdname, TransferOfferGeomObject='will provide', rc=rc)
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    enddo
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
 
@@ -354,7 +438,6 @@ module atm_comp_nuopc
     integer                 :: modeldt                   ! integer timestep
     real(R8)                :: nextsw_cday               ! calendar of next atm sw
     logical                 :: connected                 ! is field connected?
-    integer                 :: klon, klat
     integer                 :: lsize
     integer                 :: iam
     real(r8), pointer       :: lon(:),lat(:)
@@ -459,7 +542,7 @@ module atm_comp_nuopc
          inst_suffix, inst_name, logunit, read_restart, &
          scmMode, scmlat, scmlon, &
          orbEccen, orbMvelpp, orbLambm0, orbObliqr, &
-         calendar, modeldt, current_ymd, current_tod, current_mon)
+         calendar, modeldt, current_ymd, current_tod, current_mon, atm_prognostic)
 
     !----------------------------------------------------------------------------
     ! Set nextsw_cday
@@ -486,8 +569,7 @@ module atm_comp_nuopc
     allocate(lon(lsize))
     allocate(lat(lsize))
     allocate(gindex(lsize))
-    klat = mct_aVect_indexRA(ggrid%data, 'lat')
-    klon = mct_aVect_indexRA(ggrid%data, 'lon')
+
     call mpi_comm_rank(mpicom, iam, ierr)
     call mct_gGrid_exportRattr(ggrid,'lon',lon,lsize)
     call mct_gGrid_exportRattr(ggrid,'lat',lat,lsize)
@@ -502,24 +584,34 @@ module atm_comp_nuopc
 
     !--------------------------------
     ! realize the actively coupled fields, now that a mesh is established
-    ! Note: shr_nuopc_fldList_Realize does the following:
-    ! 1) loops over all of the entries in fldListTo and fldListFr creates a field
-    !    for each one via one of the following commands:
-    !     field = ESMF_FieldCreate(grid, ESMF_TYPEKIND_R8, name=shortname, rc=rc)
-    !     field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=shortname, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
+    ! Note: the following will occur in the realize call
+    ! 1) loop over all of the entries in fldsToAtm and fldsFrAtm to creates a field via the following call:
+    !    field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=shortname, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
     ! 2) realizes the field via the following call
-    !     call NUOPC_Realize(state, field=field, rc=rc)
+    !    call NUOPC_Realize(state, field=field, rc=rc)
     !    where state is either importState or exportState
     !  NUOPC_Realize "realizes" a previously advertised field in the importState and exportState
     !  by replacing the advertised fields with the newly created fields of the same name.
     !--------------------------------
 
-    call shr_nuopc_fldList_Realize(importState, fldListTo(compatm), flds_scalar_name, flds_scalar_num, &
-         mesh=Emesh, tag=subname//':datmImport', rc=rc)
+    call fld_list_realize( &
+         state=ExportState, &
+         fldList=fldsFrAtm, &
+         numflds=fldsFrAtm_num, &
+         flds_scalar_name=flds_scalar_name, &
+         flds_scalar_num=flds_scalar_num, &
+         tag=subname//':datmExport',&
+         mesh=Emesh, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_fldList_Realize(exportState, fldListFr(compatm), flds_scalar_name, flds_scalar_num, &
-         mesh=Emesh, tag=subname//':datmExport', rc=rc)
+    call fld_list_realize( &
+         state=importState, &
+         fldList=fldsToAtm, &
+         numflds=fldsToAtm_num, &
+         flds_scalar_name=flds_scalar_name, &
+         flds_scalar_num=flds_scalar_num, &
+         tag=subname//':datmImport',&
+         mesh=Emesh, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -734,7 +826,8 @@ module atm_comp_nuopc
          target_mon=mon, &
          calendar=calendar, &
          modeldt=modeldt, &
-         case_name=case_name)
+         case_name=case_name, &
+         atm_prognostic=atm_prognostic)
 
     ! Use nextYMD and nextTOD here since since the component - clock is advance at the END of the time interval
     nextsw_cday = datm_shr_getNextRadCDay( nextYMD, nextTOD, stepno, modeldt, iradsw, calendar )
@@ -826,7 +919,7 @@ module atm_comp_nuopc
        call NUOPC_CompAttributeGet(gcomp, name="restart_option", value=restart_option, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       call NUOPC_CompAttributeGet(gcomp,  name="restart_n", value=cvalue, rc=rc)
+       call NUOPC_CompAttributeGet(gcomp, name="restart_n", value=cvalue, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) restart_n
 
@@ -886,5 +979,136 @@ module atm_comp_nuopc
   end subroutine ModelFinalize
 
   !===============================================================================
+
+  subroutine fld_list_add(num, fldlist, stdname, flds_concat)
+    integer,                    intent(inout) :: num
+    type(fld_list_type),        intent(inout) :: fldlist(:)
+    character(len=*),           intent(in)    :: stdname
+    character(len=*), optional, intent(inout) :: flds_concat
+
+    ! local variables
+    integer :: rc
+    character(len=*), parameter :: subname='(atm_comp_nuopc:fld_list_add)'
+    !-------------------------------------------------------------------------------
+
+    ! Set up a list of field information
+
+    num = num + 1
+    if (num > fldsMax) then
+      call ESMF_LogWrite(trim(subname)//": ERROR num > fldsMax "//trim(stdname), &
+        ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__, rc=dbrc)
+      return
+    endif
+    fldlist(num)%stdname        = trim(stdname)
+
+    if (present(flds_concat)) then
+       if (len_trim(flds_concat) + len_trim(stdname) + 1 >= len(flds_concat)) then
+          call ESMF_LogWrite(subname//': ERROR: max len of flds_concat has been exceeded', &
+               ESMF_LOGMSG_ERROR, line=__LINE__, file= u_FILE_u, rc=dbrc)
+       end if
+       if (trim(flds_concat) == '') then
+          flds_concat = trim(stdname)
+       else
+          flds_concat = trim(flds_concat)//':'//trim(stdname)
+       end if
+    end if
+
+  end subroutine fld_list_add
+
+  !===============================================================================
+
+  subroutine fld_list_realize(state, fldList, numflds, flds_scalar_name, flds_scalar_num, mesh, tag, rc)
+
+    use NUOPC , only : NUOPC_IsConnected, NUOPC_Realize
+    use ESMF  , only : ESMF_MeshLoc_Element, ESMF_FieldCreate, ESMF_TYPEKIND_R8
+    use ESMF  , only : ESMF_MAXSTR, ESMF_Field, ESMF_State, ESMF_Mesh, ESMF_StateRemove 
+    use ESMF  , only : ESMF_LogFoundError, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_ERROR, ESMF_LOGERR_PASSTHRU
+
+    type(ESMF_State)    , intent(inout) :: state
+    type(fld_list_type) , intent(in)    :: fldList(:)
+    integer             , intent(in)    :: numflds
+    character(len=*)    , intent(in)    :: flds_scalar_name
+    integer             , intent(in)    :: flds_scalar_num
+    character(len=*)    , intent(in)    :: tag
+    type(ESMF_Mesh)     , intent(in)    :: mesh
+    integer             , intent(inout) :: rc
+
+    ! local variables
+    integer                :: n
+    type(ESMF_Field)       :: field
+    character(len=80)      :: stdname
+    character(len=*),parameter  :: subname='(atm_comp_nuopc:fld_list_realize)'
+    ! ----------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    do n = 1, numflds
+       stdname = fldList(n)%stdname
+       if (NUOPC_IsConnected(state, fieldName=stdname)) then
+          if (stdname == trim(flds_scalar_name)) then
+             call ESMF_LogWrite(trim(subname)//trim(tag)//" Field = "//trim(stdname)//" is connected on root pe", &
+                  ESMF_LOGMSG_INFO, rc=dbrc)
+             ! Create the scalar field
+             call SetScalarField(field, flds_scalar_name, flds_scalar_num, rc=rc)
+             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+          else
+             call ESMF_LogWrite(trim(subname)//trim(tag)//" Field = "//trim(stdname)//" is connected using mesh", &
+                  ESMF_LOGMSG_INFO, rc=dbrc)
+             ! Create the field
+             field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=stdname, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
+             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+          endif
+
+          ! NOW call NUOPC_Realize
+          call NUOPC_Realize(state, field=field, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+       else
+          if (stdname /= trim(flds_scalar_name)) then
+             call ESMF_LogWrite(subname // trim(tag) // " Field = "// trim(stdname) // " is not connected.", &
+                  ESMF_LOGMSG_INFO, rc=dbrc)
+             call ESMF_StateRemove(state, (/stdname/), rc=rc)
+             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+          end if
+       end if
+    end do
+
+  contains  !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    subroutine SetScalarField(field, flds_scalar_name, flds_scalar_num, rc)
+      ! ----------------------------------------------
+      ! create a field with scalar data on the root pe
+      ! ----------------------------------------------
+      use ESMF, only : ESMF_Field, ESMF_DistGrid, ESMF_Grid
+      use ESMF, only : ESMF_DistGridCreate, ESMF_GridCreate, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
+      use ESMF, only : ESMF_FieldCreate, ESMF_GridCreate, ESMF_TYPEKIND_R8
+
+      type(ESMF_Field) , intent(inout) :: field
+      character(len=*) , intent(in)    :: flds_scalar_name
+      integer          , intent(in)    :: flds_scalar_num
+      integer          , intent(inout) :: rc
+
+      ! local variables
+      type(ESMF_Distgrid) :: distgrid
+      type(ESMF_Grid)     :: grid
+      character(len=*), parameter :: subname='(SetScalarField)'
+      ! ----------------------------------------------
+
+      rc = ESMF_SUCCESS
+
+      ! create a DistGrid with a single index space element, which gets mapped onto DE 0.
+      distgrid = ESMF_DistGridCreate(minIndex=(/1/), maxIndex=(/1/), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+
+      grid = ESMF_GridCreate(distgrid, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+
+      field = ESMF_FieldCreate(name=trim(flds_scalar_name), grid=grid, typekind=ESMF_TYPEKIND_R8, &
+           ungriddedLBound=(/1/), ungriddedUBound=(/flds_scalar_num/), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+
+    end subroutine SetScalarField
+
+  end subroutine fld_list_realize
 
 end module atm_comp_nuopc

--- a/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
@@ -5,16 +5,16 @@ module atm_comp_nuopc
   !----------------------------------------------------------------------------
 
   use med_constants_mod     , only : IN, R8, I8, CXX
-  use shr_log_mod           , only : shr_log_Unit
-  use shr_cal_mod           , only : shr_cal_ymd2date, shr_cal_noleap, shr_cal_gregorian
-  use shr_file_mod          , only : shr_file_getlogunit, shr_file_setlogunit
-  use shr_file_mod          , only : shr_file_getloglevel, shr_file_setloglevel
-  use shr_file_mod          , only : shr_file_setIO, shr_file_getUnit
-  use esmFlds               , only : flds_scalar_name
-  use esmFlds               , only : flds_scalar_num
-  use esmFlds               , only : flds_scalar_index_nx
-  use esmFlds               , only : flds_scalar_index_ny
-  use esmFlds               , only : flds_scalar_index_nextsw_cday
+  use med_constants_mod     , only : shr_log_Unit
+  use med_constants_mod     , only : shr_cal_ymd2date, shr_cal_noleap, shr_cal_gregorian
+  use med_constants_mod     , only : shr_file_getlogunit, shr_file_setlogunit
+  use med_constants_mod     , only : shr_file_getloglevel, shr_file_setloglevel
+  use med_constants_mod     , only : shr_file_setIO, shr_file_getUnit
+  use shr_nuopc_scalars_mod , only : flds_scalar_name
+  use shr_nuopc_scalars_mod , only : flds_scalar_num
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_nx
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_ny
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_nextsw_cday
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_Realize
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_Concat
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_Deactivate
@@ -56,8 +56,8 @@ module atm_comp_nuopc
   private :: ModelAdvance
   private :: ModelSetRunClock
   private :: ModelFinalize
-  private :: flds_list_add
-  private :: flds_list_realize
+  private :: fld_list_add
+  private :: fld_list_realize
 
   !--------------------------------------------------------------------------
   ! Private module data
@@ -537,13 +537,39 @@ module atm_comp_nuopc
     call ESMF_TimeIntervalGet( timeStep, s=modeldt, rc=rc )
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call datm_comp_init(clock, x2d, d2x, &
-         flds_x2a, flds_a2x, &
-         SDATM, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-         inst_suffix, inst_name, logunit, read_restart, &
-         scmMode, scmlat, scmlon, &
-         orbEccen, orbMvelpp, orbLambm0, orbObliqr, &
-         calendar, modeldt, current_ymd, current_tod, current_mon, atm_prognostic)
+    !----------------------------------------------------------------------------
+    ! Initialize model
+    !----------------------------------------------------------------------------
+
+    call datm_comp_init(&
+         x2d, &
+         d2x, &
+         flds_x2a, &
+         flds_a2x, &
+         SDATM, &
+         gsmap, &
+         ggrid, &
+         mpicom, &
+         compid, &
+         my_task,&
+         master_task, &
+         inst_suffix, &
+         inst_name, &
+         logunit, &
+         read_restart, &
+         scmMode, &
+         scmlat, &
+         scmlon, &
+         orbEccen, &
+         orbMvelpp, &
+         orbLambm0, &
+         orbObliqr, &
+         calendar, &
+         modeldt, &
+         current_ymd, &
+         current_tod, &
+         current_mon, &
+         atm_prognostic)
 
     !----------------------------------------------------------------------------
     ! Set nextsw_cday
@@ -805,7 +831,7 @@ module atm_comp_nuopc
 
     ! Advance the model
 
-    call datm_comp_run(clock, &
+    call datm_comp_run(&
          x2a=x2d, &
          a2x=d2x, &
          SDATM=SDATM, &

--- a/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
@@ -2179,7 +2179,7 @@ n    </desc>
   <entry id="flds_co2a">
     <type>logical</type>
     <category>flds</category>
-    <group>FLDS_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       Previously, new fields that were needed to be passed between components
       for certain compsets were specified by cpp-variables. This has been
@@ -2196,7 +2196,7 @@ n    </desc>
   <entry id="flds_co2b">
     <type>logical</type>
     <category>flds</category>
-    <group>FLDS_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       Previously, new fields that were needed to be passed between components
       for certain compsets were specified by cpp-variables. This has been
@@ -2213,7 +2213,7 @@ n    </desc>
   <entry id="flds_co2c">
     <type>logical</type>
     <category>flds</category>
-    <group>FLDS_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       Previously, new fields that were needed to be passed between components
       for certain compsets were specified by cpp-variables. This has been
@@ -2230,7 +2230,7 @@ n    </desc>
   <entry id="flds_bgc_oi">
     <type>logical</type>
     <category>seq_flds</category>
-    <group>seq_cplflds_inparm</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       If set to .true. BGC fields will be passed back and forth between the ocean and seaice
       via the coupler.
@@ -2245,7 +2245,7 @@ n    </desc>
   <entry  id="flds_wiso" modify_via_xml="FLDS_WISO">
     <type>logical</type>
     <category>flds</category>
-    <group>FLDS_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       Pass water isotopes between components
     </desc>
@@ -2257,7 +2257,7 @@ n    </desc>
   <entry  id="glc_nec" modify_via_xml="GLC_NEC">
     <type>integer</type>
     <category>flds</category>
-    <group>FLDS_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       Number of cism elevation classes. Set by the xml variable GLC_NEC in env_run.xml
     </desc>
@@ -2269,7 +2269,7 @@ n    </desc>
   <entry id="ice_ncat" modify_via_xml="ICE_NCAT">
     <type>integer</type>
     <category>flds</category>
-    <group>FLDS_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>
       Number of sea ice thickness categories. Set by the xml variable ICE_NCAT in env_build.xml
     </desc>
@@ -2277,20 +2277,6 @@ n    </desc>
       <value>$ICE_NCAT</value>
     </values>
   </entry>
-
-  <entry id="flux_diurnal">
-    <type>logical</type>
-    <category>control</category>
-    <group>FLDS_attributes</group>
-    <desc>
-      If true, turn on diurnal cycle in computing atm/ocn fluxes
-      default: false
-    </desc>
-    <values>
-      <value>.false.</value>
-    </values>
-  </entry>
-
 
   <!-- =========================== -->
   <!-- CLOCK Attributes            -->

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -4,9 +4,9 @@ module ESM
   ! Code that specializes generic ESM Component code.
   !-----------------------------------------------------------------------------
 
-  use ESMF, only : ESMF_Clock
-  use med_constants_mod, only : dbug_flag => med_constants_dbug_flag
-  use shr_nuopc_methods_mod, only : shr_nuopc_methods_ChkErr
+  use ESMF                  , only : ESMF_Clock
+  use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
+  use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
 
   use shr_kind_mod          , only : SHR_KIND_R8, SHR_KIND_CS, SHR_KIND_CL
   use shr_log_mod           , only : shr_log_Unit, shr_log_Level
@@ -14,16 +14,6 @@ module ESM
 
   implicit none
   private
-
-  character(len=512)             :: msgstr
-  logical                        :: mastertask ! master processor for driver gcomp
-  integer                        :: componentCount
-  character(len=32), allocatable :: compLabels(:)
-  character(len=8)               :: atm_present, lnd_present, ocn_present
-  character(len=8)               :: ice_present, rof_present, wav_present
-  character(len=8)               :: glc_present, med_present
-  character(*), parameter        :: nlfilename = "drv_in" ! input namelist filename
-  character(*), parameter        :: u_FILE_u = __FILE__
 
   type(ESMF_Clock), target :: EClock_d
   type(ESMF_Clock), target :: EClock_a
@@ -34,6 +24,17 @@ module ESM
   type(ESMF_Clock), target :: EClock_r
   type(ESMF_Clock), target :: EClock_w
   type(ESMF_Clock), target :: EClock_e
+
+  character(len=512)             :: msgstr
+  logical                        :: mastertask ! master processor for driver gcomp
+  integer                        :: componentCount
+  character(len=32), allocatable :: compLabels(:)
+  character(len=8)               :: atm_present, lnd_present, ocn_present
+  character(len=8)               :: ice_present, rof_present, wav_present
+  character(len=8)               :: glc_present, med_present
+  character(*), parameter        :: nlfilename = "drv_in" ! input namelist filename
+  character(*), parameter        :: u_FILE_u = &
+       __FILE__
 
   public  :: SetServices
 
@@ -50,20 +51,20 @@ module ESM
 !================================================================================
 
   subroutine SetServices(driver, rc)
-    use NUOPC, only : NUOPC_CompDerive, NUOPC_CompSpecialize, NUOPC_CompSetInternalEntryPoint
-    use NUOPC_Driver, only : driver_routine_SS                    => SetServices
-    use NUOPC_Driver, only : driver_label_SetModelServices => label_SetModelServices
-    use NUOPC_Driver, only : driver_label_SetRunSequence  => label_SetRunSequence
-    use ESMF, only : ESMF_GridComp, ESMF_Config, ESMF_GridCompSet, ESMF_ConfigLoadFile
-    use ESMF, only : ESMF_ConfigCreate, ESMF_METHOD_INITIALIZE
-    use ESMF, only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+    use NUOPC        , only : NUOPC_CompDerive, NUOPC_CompSpecialize, NUOPC_CompSetInternalEntryPoint
+    use NUOPC_Driver , only : driver_routine_SS             => SetServices
+    use NUOPC_Driver , only : driver_label_SetModelServices => label_SetModelServices
+    use NUOPC_Driver , only : driver_label_SetRunSequence   => label_SetRunSequence
+    use ESMF         , only : ESMF_GridComp, ESMF_Config, ESMF_GridCompSet, ESMF_ConfigLoadFile
+    use ESMF         , only : ESMF_ConfigCreate, ESMF_METHOD_INITIALIZE
+    use ESMF         , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
 
     type(ESMF_GridComp)  :: driver
     integer, intent(out) :: rc
 
     ! local variables
-    type(ESMF_Config)           :: config
-    integer :: dbrc
+    type(ESMF_Config) :: config
+    integer           :: dbrc
     character(len=*), parameter :: subname = "(esm.F90:SetServices)"
     !---------------------------------------
 
@@ -109,22 +110,22 @@ module ESM
   !================================================================================
 
   subroutine SetModelServices(driver, rc)
-    use ESMF, only : ESMF_GridComp, ESMF_VM, ESMF_Config, ESMF_VMBarrier
-    use ESMF, only : ESMF_GridCompGet, ESMF_VMGet, ESMF_ConfigGetAttribute
-    use ESMF, only : ESMF_ConfigGetLen, ESMF_RC_NOT_VALID, ESMF_LogFoundAllocError
-    use ESMF, only : ESMF_LogSetError, ESMF_LogWrite, ESMF_LOGMSG_INFO
-    use ESMF, only : ESMF_GridCompSet, ESMF_SUCCESS, ESMF_METHOD_INITIALIZE
-    use NUOPC, only : NUOPC_CompSetInternalEntryPoint, NUOPC_CompAttributeGet
-    use NUOPC_Driver, only : NUOPC_DriverAddComp
+    use ESMF                  , only : ESMF_GridComp, ESMF_VM, ESMF_Config, ESMF_VMBarrier
+    use ESMF                  , only : ESMF_GridCompGet, ESMF_VMGet, ESMF_ConfigGetAttribute
+    use ESMF                  , only : ESMF_ConfigGetLen, ESMF_RC_NOT_VALID, ESMF_LogFoundAllocError
+    use ESMF                  , only : ESMF_LogSetError, ESMF_LogWrite, ESMF_LOGMSG_INFO
+    use ESMF                  , only : ESMF_GridCompSet, ESMF_SUCCESS, ESMF_METHOD_INITIALIZE
+    use NUOPC                 , only : NUOPC_CompSetInternalEntryPoint, NUOPC_CompAttributeGet
+    use NUOPC_Driver          , only : NUOPC_DriverAddComp
     use MED                   , only : med_SS => SetServices
     use esmFlds               , only : esmFlds_Init, esmFlds_Concat
     use seq_comm_mct          , only : CPLID, GLOID, ATMID, LNDID, OCNID, ICEID, GLCID, ROFID, WAVID, ESPID
-    use seq_comm_mct, only : num_inst_total
-    use seq_comm_mct, only : seq_comm_init, seq_comm_printcomms, seq_comm_petlist
+    use seq_comm_mct          , only : num_inst_total
+    use seq_comm_mct          , only : seq_comm_init, seq_comm_printcomms, seq_comm_petlist
     use seq_comm_mct          , only : seq_comm_getinfo => seq_comm_setptrs
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_Clock_TimePrint
     use shr_pio_mod           , only : shr_pio_init1
-    use mpi, only : MPI_COMM_WORLD
+    use mpi                   , only : MPI_COMM_WORLD
     use shr_file_mod          , only : shr_file_getlogunit, shr_file_setLogunit
     use shr_file_mod          , only : shr_file_getlogLevel, shr_file_setLogLevel
     use shr_file_mod          , only : shr_file_getUnit, shr_file_freeUnit
@@ -136,29 +137,28 @@ module ESM
     use rof_comp_nuopc        , only : ROFSetServices => SetServices
     use glc_comp_nuopc        , only : GLCSetServices => SetServices
 
-
-    type(ESMF_GridComp)  :: driver
-    integer, intent(out) :: rc
+    type(ESMF_GridComp)    :: driver
+    integer, intent(out)   :: rc
 
     ! local variables
-    type(ESMF_VM)                  :: vm
-    type(ESMF_GridComp)            :: child
-    type(ESMF_Config)              :: config
-    integer                        :: compid
-    integer                        :: n, n1, stat
-    integer, pointer               :: petList(:)
-    character(len=20)              :: model, prefix
-    integer                        :: petCount, i
-    integer                        :: localPet
-    logical                        :: is_set
-    character(SHR_KIND_CS)         :: cvalue
-    character(len=512)             :: diro
-    character(len=512)             :: logfile
-    integer                        :: shrlogunit ! original log unit
-    integer                        :: shrloglev  ! original log level
-    integer                        :: global_comm
-    logical                        :: iamroot_med           ! mediator masterproc
-    integer :: dbrc
+    type(ESMF_VM)          :: vm
+    type(ESMF_GridComp)    :: child
+    type(ESMF_Config)      :: config
+    integer                :: compid
+    integer                :: n, n1, stat
+    integer, pointer       :: petList(:)
+    character(len=20)      :: model, prefix
+    integer                :: petCount, i
+    integer                :: localPet
+    logical                :: is_set
+    character(SHR_KIND_CS) :: cvalue
+    character(len=512)     :: diro
+    character(len=512)     :: logfile
+    integer                :: shrlogunit  ! original log unit
+    integer                :: shrloglev   ! original log level
+    integer                :: global_comm
+    logical                :: iamroot_med ! mediator masterproc
+    integer                :: dbrc
     character(len=*), parameter    :: subname = "(esm.F90:SetModelServices)"
     !-------------------------------------------
 
@@ -564,27 +564,27 @@ module ESM
   !================================================================================
 
   subroutine SetRunSequence(driver, rc)
-    use ESMF, only : ESMF_GridComp, ESMF_LogWrite, ESMF_SUCCESS, ESMF_LOGMSG_INFO
-    use ESMF, only : ESMF_Time, ESMF_TimeInterval, ESMF_Clock, ESMF_Config
-    use ESMF, only : ESMF_GridCompGet
-    use NUOPC, only : NUOPC_FreeFormat, NUOPC_FreeFormatPrint, NUOPC_FreeFormatDestroy
-    use NUOPC, only : NUOPC_FreeFormatCreate
-    use NUOPC_Driver, only : NUOPC_DriverIngestRunSequence, NUOPC_DriverSetRunSequence
-    use NUOPC_Driver, only : NUOPC_DriverPrint
+    use ESMF                  , only : ESMF_GridComp, ESMF_LogWrite, ESMF_SUCCESS, ESMF_LOGMSG_INFO
+    use ESMF                  , only : ESMF_Time, ESMF_TimeInterval, ESMF_Clock, ESMF_Config
+    use ESMF                  , only : ESMF_GridCompGet
+    use NUOPC                 , only : NUOPC_FreeFormat, NUOPC_FreeFormatPrint, NUOPC_FreeFormatDestroy
+    use NUOPC                 , only : NUOPC_FreeFormatCreate
+    use NUOPC_Driver          , only : NUOPC_DriverIngestRunSequence, NUOPC_DriverSetRunSequence
+    use NUOPC_Driver          , only : NUOPC_DriverPrint
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_Clock_TimePrint
 
     type(ESMF_GridComp)  :: driver
     integer, intent(out) :: rc
 
     ! local variables
-    integer                       :: localrc
-    type(ESMF_Time)               :: startTime
-    type(ESMF_Time)               :: stopTime
-    type(ESMF_TimeInterval)       :: timeStep
-    type(ESMF_Clock)              :: internalClock
-    type(ESMF_Config)             :: config
-    type(NUOPC_FreeFormat)        :: runSeqFF
-    integer :: dbrc
+    integer                 :: localrc
+    type(ESMF_Time)         :: startTime
+    type(ESMF_Time)         :: stopTime
+    type(ESMF_TimeInterval) :: timeStep
+    type(ESMF_Clock)        :: internalClock
+    type(ESMF_Config)       :: config
+    type(NUOPC_FreeFormat)  :: runSeqFF
+    integer                 :: dbrc
     character(len=*), parameter :: subname = "(esm.F90:SetRunSequence)"
 
     rc = ESMF_SUCCESS
@@ -652,10 +652,11 @@ module ESM
   !================================================================================
 
   recursive subroutine ModifyCplLists(driver, importState, exportState, clock, rc)
-    use ESMF, only : ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_LogWrite
-    use ESMF, only : ESMF_LOGMSG_INFO, ESMF_CplComp, ESMF_SUCCESS
-    use NUOPC, only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet
-    use NUOPC_Driver, only : NUOPC_DriverGetComp
+
+    use ESMF         , only : ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_LogWrite
+    use ESMF         , only : ESMF_LOGMSG_INFO, ESMF_CplComp, ESMF_SUCCESS
+    use NUOPC        , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet
+    use NUOPC_Driver , only : NUOPC_DriverGetComp
 
     type(ESMF_GridComp)  :: driver
     type(ESMF_State)     :: importState, exportState
@@ -666,7 +667,7 @@ module ESM
     integer                         :: i, j, cplListSize
     character(len=160), allocatable :: cplList(:)
     character(len=160)              :: tempString
-    integer :: dbrc
+    integer                         :: dbrc
     character(len=*), parameter :: subname = "(esm.F90:ModifyCplLists)"
 
     rc = ESMF_SUCCESS
@@ -729,20 +730,20 @@ module ESM
     !----------------------------------------------------------
     ! Initialize MPI communicators,  IO and threading
     !----------------------------------------------------------
-    use ESMF, only : ESMF_GridComp, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_SUCCESS
-    use NUOPC, only : NUOPC_CompAttributeGet
-    use shr_pio_mod           , only : shr_pio_init2
-    use mpi, only : MPI_COMM_NULL
-    use seq_comm_mct          , only : CPLID, GLOID, ATMID, LNDID, OCNID, ICEID, GLCID, ROFID, WAVID, ESPID
-    use seq_comm_mct          , only : num_inst_atm, num_inst_lnd, num_inst_rof
-    use seq_comm_mct          , only : num_inst_ocn, num_inst_ice, num_inst_glc
-    use seq_comm_mct          , only : num_inst_wav, num_inst_esp, num_inst_total
-    use shr_mem_mod           , only : shr_mem_init
-    use seq_comm_mct          , only : seq_comm_inst, seq_comm_name, seq_comm_suffix
-    use seq_comm_mct          , only : seq_comm_setnthreads, seq_comm_getnthreads
-    use seq_comm_mct          , only : seq_comm_iamin, seq_comm_name, seq_comm_namelen, seq_comm_iamroot
-    use seq_comm_mct          , only : seq_comm_getinfo => seq_comm_setptrs
-    use perf_mod,  only : t_initf
+    use ESMF         , only : ESMF_GridComp, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_SUCCESS
+    use NUOPC        , only : NUOPC_CompAttributeGet
+    use shr_pio_mod  , only : shr_pio_init2
+    use mpi          , only : MPI_COMM_NULL
+    use seq_comm_mct , only : CPLID, GLOID, ATMID, LNDID, OCNID, ICEID, GLCID, ROFID, WAVID, ESPID
+    use seq_comm_mct , only : num_inst_atm, num_inst_lnd, num_inst_rof
+    use seq_comm_mct , only : num_inst_ocn, num_inst_ice, num_inst_glc
+    use seq_comm_mct , only : num_inst_wav, num_inst_esp, num_inst_total
+    use shr_mem_mod  , only : shr_mem_init
+    use seq_comm_mct , only : seq_comm_inst, seq_comm_name, seq_comm_suffix
+    use seq_comm_mct , only : seq_comm_setnthreads, seq_comm_getnthreads
+    use seq_comm_mct , only : seq_comm_iamin, seq_comm_name, seq_comm_namelen, seq_comm_iamroot
+    use seq_comm_mct , only : seq_comm_getinfo => seq_comm_setptrs
+    use perf_mod     , only : t_initf
 
     ! input/output variables
     type(ESMF_GridComp), intent(inout) :: driver
@@ -927,14 +928,14 @@ module ESM
     ! Determine if will restart and read pointer file
     ! if appropriate
     !-----------------------------------------------------
-    use shr_sys_mod           , only : shr_sys_abort
-    use ESMF, only : ESMF_GridComp, ESMF_VM, ESMF_GridCompGet, ESMF_VMGet, ESMF_SUCCESS
-    use ESMF, only : ESMF_LogSetError, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_RC_NOT_VALID
-    use NUOPC, only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
-    use shr_file_mod          , only : shr_file_getUnit, shr_file_freeUnit
-    use shr_mpi_mod           , only : shr_mpi_bcast
+    use ESMF         , only : ESMF_GridComp, ESMF_VM, ESMF_GridCompGet, ESMF_VMGet, ESMF_SUCCESS
+    use ESMF         , only : ESMF_LogSetError, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_RC_NOT_VALID
+    use NUOPC        , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
+    use shr_sys_mod  , only : shr_sys_abort
+    use shr_file_mod , only : shr_file_getUnit, shr_file_freeUnit
+    use shr_mpi_mod  , only : shr_mpi_bcast
 
-  ! input/output variables
+    ! input/output variables
     type(ESMF_GridComp)    , intent(inout) :: driver
     integer                , intent(out)   :: rc
 
@@ -1016,10 +1017,10 @@ module ESM
     !----------------------------------------------------------
     ! Initialize time manager
     !----------------------------------------------------------
-    use ESMF, only : ESMF_GridComp, ESMF_Clock, ESMF_VM, ESMF_GridCompGet, ESMF_VMGet
-    use ESMF, only : ESMF_LogWrite, ESMF_SUCCESS, ESMF_LOGMSG_INFO
-    use pio, only : pio_file_is_open, pio_closefile, file_desc_t
-    use seq_timemgr_mod       , only : seq_timemgr_clockInit
+    use ESMF            , only : ESMF_GridComp, ESMF_Clock, ESMF_VM, ESMF_GridCompGet, ESMF_VMGet
+    use ESMF            , only : ESMF_LogWrite, ESMF_SUCCESS, ESMF_LOGMSG_INFO
+    use pio             , only : pio_file_is_open, pio_closefile, file_desc_t
+    use seq_timemgr_mod , only : seq_timemgr_clockInit
 
     ! INPUT/OUTPUT PARAMETERS:
     type(ESMF_GridComp)    , intent(inout) :: driver
@@ -1070,24 +1071,24 @@ module ESM
   !================================================================================
 
   subroutine InitAttributes(driver, rc)
-    use shr_sys_mod           , only : shr_sys_abort
-    use ESMF, only : ESMF_GridComp, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LogSetError, ESMF_LOGMSG_INFO
-    use ESMF, only : ESMF_RC_NOT_VALID
-    use NUOPC, only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
-    use shr_orb_mod           , only : shr_orb_params, SHR_ORB_UNDEF_INT, SHR_ORB_UNDEF_REAL
-    use seq_comm_mct          , only : CPLID, OCNID
-    use seq_comm_mct          , only : seq_comm_getinfo => seq_comm_setptrs
-    use shr_assert_mod        , only : shr_assert_in_domain
-    use shr_cal_mod           , only : shr_cal_date2ymd
-    use shr_const_mod         , only : shr_const_tkfrz, shr_const_tktrip
-    use shr_const_mod         , only : shr_const_mwwv, shr_const_mwdair
-    use shr_frz_mod           , only : shr_frz_freezetemp_init
-    use shr_reprosum_mod      , only : shr_reprosum_setopts
-    use seq_timemgr_mod       , only : seq_timemgr_EClockGetData
-    use shr_wv_sat_mod        , only : shr_wv_sat_set_default, shr_wv_sat_init
-    use shr_wv_sat_mod        , only : shr_wv_sat_make_tables, ShrWVSatTableSpec
-    use shr_wv_sat_mod        , only : shr_wv_sat_get_scheme_idx, shr_wv_sat_valid_idx
-!    use shr_scam_mod          , only : shr_scam_checkSurface
+    use shr_sys_mod      , only : shr_sys_abort
+    use ESMF             , only : ESMF_GridComp, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LogSetError, ESMF_LOGMSG_INFO
+    use ESMF             , only : ESMF_RC_NOT_VALID
+    use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
+    use shr_orb_mod      , only : shr_orb_params, SHR_ORB_UNDEF_INT, SHR_ORB_UNDEF_REAL
+    use seq_comm_mct     , only : CPLID, OCNID
+    use seq_comm_mct     , only : seq_comm_getinfo => seq_comm_setptrs
+    use shr_assert_mod   , only : shr_assert_in_domain
+    use shr_cal_mod      , only : shr_cal_date2ymd
+    use shr_const_mod    , only : shr_const_tkfrz, shr_const_tktrip
+    use shr_const_mod    , only : shr_const_mwwv, shr_const_mwdair
+    use shr_frz_mod      , only : shr_frz_freezetemp_init
+    use shr_reprosum_mod , only : shr_reprosum_setopts
+    use seq_timemgr_mod  , only : seq_timemgr_EClockGetData
+    use shr_wv_sat_mod   , only : shr_wv_sat_set_default, shr_wv_sat_init
+    use shr_wv_sat_mod   , only : shr_wv_sat_make_tables, ShrWVSatTableSpec
+    use shr_wv_sat_mod   , only : shr_wv_sat_get_scheme_idx, shr_wv_sat_valid_idx
+   !use shr_scam_mod     , only : shr_scam_checkSurface
 
     ! input/output variables
     type(ESMF_GridComp) , intent(inout) :: driver
@@ -1103,7 +1104,6 @@ module ESM
     logical                         :: reprosum_use_ddpdd    ! setup reprosum, use ddpdd
     real(SHR_KIND_R8)               :: reprosum_diffmax      ! setup reprosum, set rel_diff_max
     logical                         :: reprosum_recompute    ! setup reprosum, recompute if tolerance exceeded
-    logical                         :: output_perf = .false. ! require timing data output for this pe
     integer                         :: ymd                   ! Current date (YYYYMMDD)
     integer                         :: year                  ! Current date (YYYY)
     integer                         :: month                 ! Current date (MM)
@@ -1136,13 +1136,13 @@ module ESM
     logical                         :: flag
     integer                         :: i, it, n
     integer                         :: unitn                 ! Namelist unit number to read
+    integer                         :: dbrc
     integer          , parameter    :: ens1=1                ! use first instance of ensemble only
     integer          , parameter    :: fix1=1                ! temporary hard-coding to first ensemble, needs to be fixed
     real(SHR_KIND_R8), parameter    :: epsilo = shr_const_mwwv/shr_const_mwdair
     character(len=*) , parameter    :: orb_fixed_year       = 'fixed_year'
     character(len=*) , parameter    :: orb_variable_year    = 'variable_year'
     character(len=*) , parameter    :: orb_fixed_parameters = 'fixed_parameters'
-    integer :: dbrc
     character(len=*) , parameter    :: subname = '(SetAttributes_and_InitClocks)'
     !----------------------------------------------------------
 
@@ -1521,13 +1521,14 @@ module ESM
     call ReadAttributes(gcomp, config, trim(compname)//"_modelio::", rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    call ReadAttributes(gcomp, config, "CLOCK_attributes::", rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
     if (compname == 'MED') then
 
        call ReadAttributes(gcomp, config, "MED_history_attributes::", rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       call ReadAttributes(gcomp, config, "CLOCK_attributes::", rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ReadAttributes(gcomp, config, "FLDS_attributes::", rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/drivers/nuopc/cime_flds/esmFlds.F90
+++ b/src/drivers/nuopc/cime_flds/esmFlds.F90
@@ -1,9 +1,31 @@
 module esmFlds
 
+  !---------------------------------------------------------------------
+  ! This is a mediator specific routine that determines ALL possible
+  ! fields exchanged between components and their associated routing,
+  ! mapping and merging
+  !---------------------------------------------------------------------
+
   use ESMF
   use NUOPC
-  use shr_kind_mod          , only : CX => shr_kind_CX, CXX => shr_kind_CXX, CS=>shr_kind_CS, CL=>shr_kind_CL
-  use shr_nuopc_fldList_mod , only : mapbilnr, mapconsf, mapconsd, mappatch, mapfcopy, mapunset, mapfiler 
+  use med_constants_mod     , only : IN, R8, I8, CXX, CX, CS, CL
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_nx
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_ny
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_precip_fact
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_nextsw_cday
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_dead_comps
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_rofice_present
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_flood_present
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_ocnrof_prognostic
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_iceberg_prognostic
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_glclnd_present
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_glcocn_present
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_glcice_present
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_glc_valid_input
+  use shr_nuopc_scalars_mod , only : flds_scalar_index_glc_coupled
+  use shr_nuopc_scalars_mod , only : flds_scalar_num
+  use shr_nuopc_scalars_mod , only : flds_scalar_name
+  use shr_nuopc_fldList_mod , only : mapbilnr, mapconsf, mapconsd, mappatch, mapfcopy, mapunset, mapfiler
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_type
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_AddDomain
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_AddMetaData
@@ -29,29 +51,6 @@ module esmFlds
 
   public :: esmFlds_Init
   public :: esmFlds_Concat
-
-  !----------------------------------------------------------------------------
-  ! scalars
-  !----------------------------------------------------------------------------
-
-  integer, parameter :: flds_scalar_index_nx                 = 1
-  integer, parameter :: flds_scalar_index_ny                 = 2
-  integer, parameter :: flds_scalar_index_precip_fact        = 3
-  integer, parameter :: flds_scalar_index_nextsw_cday        = 4
-  integer, parameter :: flds_scalar_index_dead_comps         = 5
-  integer, parameter :: flds_scalar_index_rofice_present     = 6  ! does rof have iceberg coupling on
-  integer, parameter :: flds_scalar_index_flood_present      = 7  ! does rof have flooding on
-  integer, parameter :: flds_scalar_index_ocnrof_prognostic  = 8  ! does ocn need rof data
-  integer, parameter :: flds_scalar_index_iceberg_prognostic = 9  ! does ice model support icebergs
-  integer, parameter :: flds_scalar_index_glclnd_present     = 10 ! does glc have land coupling fields on
-  integer, parameter :: flds_scalar_index_glcocn_present     = 11 ! does glc have ocean runoff on
-  integer, parameter :: flds_scalar_index_glcice_present     = 12 ! does glc have iceberg coupling on
-  integer, parameter :: flds_scalar_index_glc_valid_input    = 13 ! does glc have is valid accumulated data being sent to it?
-                                                                  ! (only valid of glc_prognostic is .true.)
-  integer, parameter :: flds_scalar_index_glc_coupled        = 14 ! does glc send fluxes to other components
-                                                                  ! (only relevant if glc_present is .true.)
-  integer, parameter :: flds_scalar_num                      = 14
-  character(len=*) , parameter :: flds_scalar_name = "cpl_scalars"
 
   !-----------------------------------------------
   ! Component and mapping array indices
@@ -608,7 +607,7 @@ contains
          merge_from1=compatm, merge_field1='Faxa_rainl', merge_type1='copy')
     call shr_nuopc_fldList_AddFld(fldListTo(compice)%flds, 'Faxa_rain', &
          merge_from1=compatm, merge_field1='Faxa_rainc:Faxa_rainl', merge_type1='accumulate')
-    call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Faxa_rain', & 
+    call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Faxa_rain', &
          merge_from1=compatm, merge_field1='Faxa_rainc:Faxa_rainl', merge_type1='accumulate', merge_fracname1='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, complnd, mapconsf, 'one', atm2lnd_fmapname)
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n2), compatm, complnd, mapconsf, 'one', atm2lnd_fmapname)
@@ -637,7 +636,7 @@ contains
          merge_from1=compatm, merge_field1='Faxa_snowl', merge_type1='copy')
     call shr_nuopc_fldList_AddFld(fldListTo(compice)%flds, 'Faxa_snow', &
          merge_from1=compatm, merge_field1='Faxa_snowc:Faxa_snowl', merge_type1='accumulate')
-    call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Faxa_snow', & 
+    call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Faxa_snow', &
          merge_from1=compatm, merge_field1='Faxa_snowc:Faxa_snowl', merge_type1='accumulate', merge_fracname1='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, complnd, mapconsf, 'one', atm2lnd_fmapname)
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n2), compatm, complnd, mapconsf, 'one', atm2lnd_fmapname)
@@ -738,7 +737,7 @@ contains
     call shr_nuopc_fldList_AddMetadata(fldname="Faii_swnet", longname=longname, stdname=stdname, units=units)
     call shr_nuopc_fldList_AddMetadata(fldname="Foxx_swnet", longname=longname, stdname=stdname, units=units)
     call shr_nuopc_fldList_AddFld(fldListFr(compatm)%flds, 'Faxa_swnet', fldindex=n1)  ! only diagnostic
-    call shr_nuopc_fldList_AddFld(fldListFr(complnd)%flds, 'Fall_swnet')              
+    call shr_nuopc_fldList_AddFld(fldListFr(complnd)%flds, 'Fall_swnet')
     call shr_nuopc_fldList_AddFld(fldListFr(compice)%flds, 'Faii_swnet', fldindex=n2)  ! only diagnostic
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Foxx_swnet') ! CUSTOM
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, compice, mapconsf, 'one'  , atm2ice_fmapname)
@@ -977,7 +976,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListFr(compice)%flds , 'Si_avsdr', fldindex=n2)
     call shr_nuopc_fldList_AddFld(fldListMed_ocnalb_o%flds, 'So_avsdr', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_avsdr', &
-         merge_from1=complnd, merge_field1='Sl_avsdr', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_avsdr', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_avsdr', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_avsdr', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_smapname)
@@ -995,7 +994,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListFr(compice)%flds , 'Si_anidr', fldindex=n2)
     call shr_nuopc_fldList_AddFld(fldListMed_ocnalb_o%flds, 'So_anidr', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_anidr', &
-         merge_from1=complnd, merge_field1='Sl_anidr', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_anidr', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_anidr', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_anidr', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_fmapname)
@@ -1013,7 +1012,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListFr(compice)%flds , 'Si_avsdf', fldindex=n2)
     call shr_nuopc_fldList_AddFld(fldListMed_ocnalb_o%flds, 'So_avsdf', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_avsdf', &
-         merge_from1=complnd, merge_field1='Sl_avsdf', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_avsdf', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_avsdf', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_avsdf', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_fmapname)
@@ -1031,7 +1030,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListFr(compice)%flds , 'Si_anidf', fldindex=n2)
     call shr_nuopc_fldList_AddFld(fldListMed_ocnalb_o%flds, 'So_anidf', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_anidf', &
-         merge_from1=complnd, merge_field1='Sl_anidf', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_anidf', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_anidf', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_anidf', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_fmapname)
@@ -1050,7 +1049,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'So_tref', fldindex=n3) ! Needed only for merging
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'So_tref', fldindex=n3) ! Needed only for merging
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_tref', &
-         merge_from1=complnd, merge_field1='Sl_tref', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_tref', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_tref', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_tref', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_fmapname)
@@ -1070,7 +1069,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'So_qref', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'So_qref', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_qref', &
-         merge_from1=complnd, merge_field1='Sl_qref', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_qref', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_qref', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_qref', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_fmapname)
@@ -1089,7 +1088,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListFr(compice)%flds, 'Si_t', fldindex=n2)
     call shr_nuopc_fldList_AddFld(fldListFr(compocn)%flds, 'So_t', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds, 'Sx_t', &
-         merge_from1=complnd, merge_field1='Sl_t', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_t', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_t', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compocn, merge_field3='So_t', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds, 'So_t', &
@@ -1174,7 +1173,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'So_u10', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'So_u10', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Sx_u10', &
-         merge_from1=complnd, merge_field1='Sl_u10', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Sl_u10', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Si_u10', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='So_u10', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1) , complnd, compatm, mapconsf, 'lfrin', lnd2atm_fmapname)
@@ -1197,7 +1196,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'Faox_taux', fldindex=n4)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'Faox_taux')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Faxx_taux', &
-         merge_from1=complnd, merge_field1='Fall_taux', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Fall_taux', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Faii_taux', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='Faox_taux', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds , 'Foxx_taux', &
@@ -1224,7 +1223,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'Faox_tauy', fldindex=n4)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'Faox_tauy')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Faxx_tauy', &
-         merge_from1=complnd, merge_field1='Fall_tauy', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Fall_tauy', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Faii_tauy', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='Faox_tauy', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Foxx_tauy', &
@@ -1249,7 +1248,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'Faox_lat', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'Faox_lat')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Faxx_lat', &
-         merge_from1=complnd, merge_field1='Fall_lat', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Fall_lat', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Faii_lat', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='Faox_lat', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds , 'Foxx_lat', &
@@ -1272,7 +1271,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'Faox_sen', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'Faox_sen')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Faxx_sen', &
-         merge_from1=complnd, merge_field1='Fall_sen', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Fall_sen', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Faii_sen', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='Faox_sen', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds , 'Foxx_sen', &
@@ -1295,7 +1294,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'Faox_lwup', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'Faox_lwup')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Faxx_lwup', &
-         merge_from1=complnd, merge_field1='Fall_lwup', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Fall_lwup', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Faii_lwup', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='Faox_lwup', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds , 'Foxx_lwup', &
@@ -1318,7 +1317,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'Faox_evap', fldindex=n3)
     call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'Faox_evap')
     call shr_nuopc_fldList_AddFld(fldListTo(compatm)%flds , 'Faxx_evap', &
-         merge_from1=complnd, merge_field1='Fall_evap', merge_type1='merge', merge_fracname1='lfrac', & 
+         merge_from1=complnd, merge_field1='Fall_evap', merge_type1='merge', merge_fracname1='lfrac', &
          merge_from2=compice, merge_field2='Faii_evap', merge_type2='merge', merge_fracname2='ifrac', &
          merge_from3=compmed, merge_field3='Faox_evap', merge_type3='merge', merge_fracname3='ofrac')
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds , 'Foxx_evap', &
@@ -1648,7 +1647,7 @@ contains
     call shr_nuopc_fldList_AddMetadata(fldname="Foxx_rofl", longname=longname, stdname=stdname, units=units)
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Foxx_rofl', &
          merge_from1=comprof, merge_field1='Forr_rofl:Flrr_flood', merge_type1='accumulate', &
-         merge_from2=compglc, merge_field2='Fogg_rofl'           , merge_type2='accumulate') 
+         merge_from2=compglc, merge_field2='Fogg_rofl'           , merge_type2='accumulate')
 
     longname = 'glc frozen runoff flux to ocean'
     stdname  = 'glacier_frozen_runoff_flux_to_ocean'
@@ -1670,7 +1669,7 @@ contains
     call shr_nuopc_fldList_AddMetadata(fldname="Foxx_rofi", longname=longname, stdname=stdname, units=units)
     call shr_nuopc_fldList_AddFld(fldListTo(compocn)%flds, 'Foxx_rofi', &
          merge_from1=comprof, merge_field1='Forr_rofi', merge_type1='accumulate', &
-         merge_from2=compglc, merge_field2='Fogg_rofi', merge_type2='accumulate') 
+         merge_from2=compglc, merge_field2='Fogg_rofi', merge_type2='accumulate')
 
     !-----------------------------
     ! rof(frozen)->ice and glc->ice
@@ -1696,7 +1695,7 @@ contains
     call shr_nuopc_fldList_AddMetadata(fldname="Fixx_rofi", longname=longname, stdname=stdname, units=units)
     call shr_nuopc_fldList_AddFld(fldListTo(compice)%flds, 'Fixx_rofi', &
          merge_from1=comprof, merge_field1='Firr_rofi', merge_type1='accumulate', &
-         merge_from2=compglc, merge_field2='Figg_rofi', merge_type2='accumulate') 
+         merge_from2=compglc, merge_field2='Figg_rofi', merge_type2='accumulate')
 
     !-----------------------------
     ! wav->ocn
@@ -1742,14 +1741,14 @@ contains
     stdname  = 'surface_downward_shortwave_flux'
     units    = 'W m-2'
     call shr_nuopc_fldList_AddMetadata(fldname="Faox_swdn", longname=longname, stdname=stdname, units=units)
-    call shr_nuopc_fldList_AddFld(FldListMed_ocnalb_o%flds, 'Faox_swdn', fldindex=n1) 
+    call shr_nuopc_fldList_AddFld(FldListMed_ocnalb_o%flds, 'Faox_swdn', fldindex=n1)
     call shr_nuopc_fldList_AddMap(fldListMed_ocnalb_o%flds(n1), compocn, compatm, mapconsf, 'ofrac', ocn2atm_smapname)
 
     longname = 'Upward solar radiation'
     stdname  = 'surface_upward_shortwave_flux'
     units    = 'W m-2'
     call shr_nuopc_fldList_AddMetadata(fldname="Faox_swup", longname=longname, stdname=stdname, units=units)
-    call shr_nuopc_fldList_AddFld(FldListMed_ocnalb_o%flds, 'Faox_swup', fldindex=n1) 
+    call shr_nuopc_fldList_AddFld(FldListMed_ocnalb_o%flds, 'Faox_swup', fldindex=n1)
     call shr_nuopc_fldList_AddMap(fldListMed_ocnalb_o%flds(n1), compocn, compatm, mapconsf, 'ofrac', ocn2atm_smapname)
 
     !-----------------------------
@@ -1781,7 +1780,7 @@ contains
     call shr_nuopc_fldList_AddFld(fldListFr(compglc)%flds   , 'Sg_icemask_coupled_fluxes', fldindex=n1)
     call shr_nuopc_fldList_AddFld(fldListTo(complnd)%flds   , 'Sg_icemask_coupled_fluxes', &
          merge_from1=compglc, merge_field1='Sg_icemask_coupled_fluxes', merge_type1='copy')
-    call shr_nuopc_fldList_AddFld(fldListMed_x2l_fr_glc%flds, 'Sg_icemask_coupled_fluxes') 
+    call shr_nuopc_fldList_AddFld(fldListMed_x2l_fr_glc%flds, 'Sg_icemask_coupled_fluxes')
     call shr_nuopc_fldList_AddMap(fldListFr(compglc)%flds(n1), compglc, complnd,  mapconsf, 'one', glc2lnd_smapname)
 
     name = 'Sg_ice_covered'

--- a/src/drivers/nuopc/cime_flds/esmFlds.F90
+++ b/src/drivers/nuopc/cime_flds/esmFlds.F90
@@ -74,7 +74,6 @@ module esmFlds
   type (shr_nuopc_fldList_type) :: fldListMed_aoflux_a
   type (shr_nuopc_fldList_type) :: fldListMed_aoflux_o
   type (shr_nuopc_fldList_type) :: fldListMed_ocnalb_o
-  type (shr_nuopc_fldList_type) :: fldListMed_aoflux_diurnl
   type (shr_nuopc_fldList_type) :: fldListMed_l2x_to_glc
   type (shr_nuopc_fldList_type) :: fldListMed_x2l_fr_glc
   type (shr_nuopc_fldList_type) :: fldListMed_g2x_to_lnd
@@ -158,7 +157,6 @@ contains
     logical                :: flds_co2b  ! use case
     logical                :: flds_co2c  ! use case
     logical                :: flds_wiso  ! use case
-    logical                :: do_flux_diurnal
     integer                :: glc_nec
     integer                :: mpicom
     character(len=*), parameter :: subname='(shr_nuopc_fldList_Init)'
@@ -210,11 +208,6 @@ contains
     read(cvalue,*) glc_nec
     call glc_elevclass_init(glc_nec)
     call ESMF_LogWrite('glc_nec = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
-
-    call NUOPC_CompAttributeGet(gcomp, name='flux_diurnal', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) do_flux_diurnal
-    call ESMF_LogWrite('flux_diurnal = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
 
     !----------------------------------------------------------
     ! Initialize mapping file names
@@ -1529,15 +1522,6 @@ contains
          merge_from1=compocn, merge_field1='So_bldepth', merge_type1='copy')
     call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compwav,  mapbilnr, 'one', 'ocn2wav_smapname')
 
-    longname = 'Fraction of sw penetrating surface layer for diurnal cycle'
-    stdname  = 'Fraction_of_sw_penetrating_surface_layer'
-    units    = '1'
-    call shr_nuopc_fldList_AddMetadata(fldname="So_fswpen", longname=longname, stdname=stdname, units=units)
-    call shr_nuopc_fldList_AddFld(fldListFr(compocn)%flds , 'So_fswpen', fldindex=n1)
-    call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'So_fswpen')
-    call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'So_fswpen')
-    call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compice,  mapfcopy, 'unset', 'unset')
-
     longname = 'Ocean melt and freeze potential'
     stdname  = 'surface_snow_and_ice_melt_heat_flux'
     units    = 'W m-2'
@@ -1767,126 +1751,6 @@ contains
     call shr_nuopc_fldList_AddMetadata(fldname="Faox_swup", longname=longname, stdname=stdname, units=units)
     call shr_nuopc_fldList_AddFld(FldListMed_ocnalb_o%flds, 'Faox_swup', fldindex=n1) 
     call shr_nuopc_fldList_AddMap(fldListMed_ocnalb_o%flds(n1), compocn, compatm, mapconsf, 'ofrac', ocn2atm_smapname)
-
-    !-----------------------------
-    ! fields for history output only
-    !-----------------------------
-
-    if (do_flux_diurnal) then
-       longname = 'atm/ocn flux temperature bulk'
-       stdname  = 'aoflux_tbulk'
-       units    = 'K'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_tbulk_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_tbulk_diurn')
-
-       longname = 'atm/ocn flux temperature skin'
-       stdname  = 'aoflux_tskin'
-       units    = 'K'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_tskin_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds,  'So_tskin_diurn')
-
-       longname = 'atm/ocn flux temperature skin at night'
-       stdname  = 'aoflux_tskin_night'
-       units    = 'K'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_tskin_night_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_tskin_night_diurn')
-
-       longname = 'atm/ocn flux temperature skin at day'
-       stdname  = 'aoflux_tskin_day'
-       units    = 'K'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_tskin_day_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_tskin_day_diurn')
-
-       longname = 'atm/ocn flux cool skin'
-       stdname  = 'aoflux_cskin'
-       units    = 'K'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_cskin_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_cskin_diurn')
-
-       longname = 'atm/ocn flux cool skin at night'
-       stdname  = 'aoflux_cskin_night'
-       units    = 'K'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_cskin_night_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_cskin_night_diurn')
-
-       longname = 'atm/ocn flux warming'
-       stdname  = 'aoflux_warm'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_warm_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_warm_diurn')
-
-       longname = 'atm/ocn flux salting'
-       stdname  = 'aoflux_salt'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_salt_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_salt_diurn')
-
-       longname = 'atm/ocn flux speed'
-       stdname  = 'aoflux_speed'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_speed_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_speed_diurn')
-
-       longname = 'atm/ocn flux regime'
-       stdname  = 'aoflux_regime'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_regime_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_regime_diurn')
-
-       longname = 'atm/ocn flux warming dialy max'
-       stdname  = 'aoflux_warmmax'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_warmmax_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_warmmax_diurn')
-
-       longname = 'atm/ocn flux wind daily max'
-       stdname  = 'aoflux_windmax'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_windmax_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_windmax_diurn')
-
-       longname = 'atm/ocn flux q-solar daily avg'
-       stdname  = 'aoflux_qsolavg'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_qsolvavg_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_qsolvavg_diurn')
-
-       longname = 'atm/ocn flux wind daily avg'
-       stdname  = 'aoflux_windavg'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_windavg_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_windavg_diurn')
-
-       longname = 'atm/ocn flux daily max increment'
-       stdname  = 'aoflux_warmmaxinc'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_warmmaxinc_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_warmmaxinc_diurn')
-
-       longname = 'atm/ocn flux wind daily max increment'
-       stdname  = 'aoflux_windmaxinc'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_windmaxinc_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_windmaxinc_diurn')
-
-       longname = 'atm/ocn flux q-solar increment'
-       stdname  = 'aoflux_qsolinc'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_qsolinc_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_qsolinc_diurn')
-
-       longname = 'atm/ocn flux wind increment'
-       stdname  = 'aoflux_windinc'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_windinc_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_windinc_diurn')
-
-       longname = 'atm/ocn flux increment counter'
-       stdname  = 'aoflux_ninc'
-       units    = 'unitless'
-       call shr_nuopc_fldList_AddMetadata(fldname="So_ninc_diurn", longname=longname, stdname=stdname, units=units)
-       call shr_nuopc_fldList_AddFld(FldListMed_aoflux_diurnl%flds, 'So_ninc_diurn')
-    end if
 
     !-----------------------------
     ! glc -> ocn

--- a/src/drivers/nuopc/mediator/med.F90
+++ b/src/drivers/nuopc/mediator/med.F90
@@ -33,46 +33,46 @@ contains
 !-----------------------------------------------------------------------------
 
   subroutine SetServices(gcomp, rc)
-    use ESMF    , only: ESMF_SUCCESS, ESMF_GridCompSetEntryPoint, ESMF_METHOD_INITIALIZE, ESMF_METHOD_RUN
-    use ESMF    , only: ESMF_GridComp, ESMF_MethodRemove
-    use NUOPC   , only: NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize, NUOPC_NOOP
-    use NUOPC_Mediator, only:  mediator_routine_SS             => SetServices
-    use NUOPC_Mediator, only:      mediator_routine_Run            => routine_Run
-    use NUOPC_Mediator, only:      mediator_label_DataInitialize   => label_DataInitialize
-    use NUOPC_Mediator, only:      mediator_label_Advance          => label_Advance
-    use NUOPC_Mediator, only:      mediator_label_CheckImport      => label_CheckImport
-    use NUOPC_Mediator, only:      mediator_label_TimestampExport  => label_TimestampExport
-    use NUOPC_Mediator, only:      mediator_label_SetRunClock      => label_SetRunClock
-    use NUOPC_Mediator, only:      mediator_label_Finalize         => label_Finalize
-    use med_phases_history_mod    , only: med_phases_history_write
-    use med_phases_restart_mod    , only: med_phases_restart_write
-    use med_connectors_mod        , only: med_connectors_prep_med2atm
-    use med_connectors_mod        , only: med_connectors_prep_med2ocn
-    use med_connectors_mod        , only: med_connectors_prep_med2ice
-    use med_connectors_mod        , only: med_connectors_prep_med2lnd
-    use med_connectors_mod        , only: med_connectors_prep_med2rof
-    use med_connectors_mod        , only: med_connectors_prep_med2wav
-    use med_connectors_mod        , only: med_connectors_prep_med2glc
-    use med_connectors_mod        , only: med_connectors_post_atm2med
-    use med_connectors_mod        , only: med_connectors_post_ocn2med
-    use med_connectors_mod        , only: med_connectors_post_ice2med
-    use med_connectors_mod        , only: med_connectors_post_lnd2med
-    use med_connectors_mod        , only: med_connectors_post_rof2med
-    use med_connectors_mod        , only: med_connectors_post_wav2med
-    use med_connectors_mod        , only: med_connectors_post_glc2med
-    use med_phases_prep_atm_mod   , only: med_phases_prep_atm
-    use med_phases_prep_ice_mod   , only: med_phases_prep_ice
-    use med_phases_prep_lnd_mod   , only: med_phases_prep_lnd
-    use med_phases_prep_rof_mod   , only: med_phases_prep_rof
-    use med_phases_prep_wav_mod   , only: med_phases_prep_wav
-    use med_phases_prep_glc_mod   , only: med_phases_prep_glc
-    use med_phases_prep_ocn_mod   , only: med_phases_prep_ocn_map
-    use med_phases_prep_ocn_mod   , only: med_phases_prep_ocn_merge
-    use med_phases_prep_ocn_mod   , only: med_phases_prep_ocn_accum_fast
-    use med_phases_prep_ocn_mod   , only: med_phases_prep_ocn_accum_avg
-    use med_phases_ocnalb_mod     , only: med_phases_ocnalb_run
-    use med_phases_aofluxes_mod   , only: med_phases_aofluxes_run
-    use med_fraction_mod          , only: med_fraction_init, med_fraction_set
+    use ESMF                    , only: ESMF_SUCCESS, ESMF_GridCompSetEntryPoint, ESMF_METHOD_INITIALIZE, ESMF_METHOD_RUN
+    use ESMF                    , only: ESMF_GridComp, ESMF_MethodRemove
+    use NUOPC                   , only: NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize, NUOPC_NOOP
+    use NUOPC_Mediator          , only: mediator_routine_SS             => SetServices
+    use NUOPC_Mediator          , only: mediator_routine_Run            => routine_Run
+    use NUOPC_Mediator          , only: mediator_label_DataInitialize   => label_DataInitialize
+    use NUOPC_Mediator          , only: mediator_label_Advance          => label_Advance
+    use NUOPC_Mediator          , only: mediator_label_CheckImport      => label_CheckImport
+    use NUOPC_Mediator          , only: mediator_label_TimestampExport  => label_TimestampExport
+    use NUOPC_Mediator          , only: mediator_label_SetRunClock      => label_SetRunClock
+    use NUOPC_Mediator          , only: mediator_label_Finalize         => label_Finalize
+    use med_phases_history_mod  , only: med_phases_history_write
+    use med_phases_restart_mod  , only: med_phases_restart_write
+    use med_connectors_mod      , only: med_connectors_prep_med2atm
+    use med_connectors_mod      , only: med_connectors_prep_med2ocn
+    use med_connectors_mod      , only: med_connectors_prep_med2ice
+    use med_connectors_mod      , only: med_connectors_prep_med2lnd
+    use med_connectors_mod      , only: med_connectors_prep_med2rof
+    use med_connectors_mod      , only: med_connectors_prep_med2wav
+    use med_connectors_mod      , only: med_connectors_prep_med2glc
+    use med_connectors_mod      , only: med_connectors_post_atm2med
+    use med_connectors_mod      , only: med_connectors_post_ocn2med
+    use med_connectors_mod      , only: med_connectors_post_ice2med
+    use med_connectors_mod      , only: med_connectors_post_lnd2med
+    use med_connectors_mod      , only: med_connectors_post_rof2med
+    use med_connectors_mod      , only: med_connectors_post_wav2med
+    use med_connectors_mod      , only: med_connectors_post_glc2med
+    use med_phases_prep_atm_mod , only: med_phases_prep_atm
+    use med_phases_prep_ice_mod , only: med_phases_prep_ice
+    use med_phases_prep_lnd_mod , only: med_phases_prep_lnd
+    use med_phases_prep_rof_mod , only: med_phases_prep_rof
+    use med_phases_prep_wav_mod , only: med_phases_prep_wav
+    use med_phases_prep_glc_mod , only: med_phases_prep_glc
+    use med_phases_prep_ocn_mod , only: med_phases_prep_ocn_map
+    use med_phases_prep_ocn_mod , only: med_phases_prep_ocn_merge
+    use med_phases_prep_ocn_mod , only: med_phases_prep_ocn_accum_fast
+    use med_phases_prep_ocn_mod , only: med_phases_prep_ocn_accum_avg
+    use med_phases_ocnalb_mod   , only: med_phases_ocnalb_run
+    use med_phases_aofluxes_mod , only: med_phases_aofluxes_run
+    use med_fraction_mod        , only: med_fraction_init, med_fraction_set
 
 
     type(ESMF_GridComp)  :: gcomp

--- a/src/drivers/nuopc/mediator/med_phases_aofluxes_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_aofluxes_mod.F90
@@ -25,7 +25,7 @@ module med_phases_aofluxes_mod
   !--------------------------------------------------------------------------
 
   type aoflux_type
-     integer            , pointer :: mask        (:) ! ocn domain mask: 0 <=> inactive cell
+     integer  , pointer :: mask        (:) ! ocn domain mask: 0 <=> inactive cell
      real(R8) , pointer :: rmask       (:) ! ocn domain mask: 0 <=> inactive cell
      real(R8) , pointer :: lats        (:) ! latitudes  (degrees)
      real(R8) , pointer :: lons        (:) ! longitudes (degrees)
@@ -58,7 +58,6 @@ module med_phases_aofluxes_mod
      real(R8) , pointer :: qref        (:) ! diagnostic:  2m ref Q
      real(R8) , pointer :: u10         (:) ! diagnostic: 10m wind speed
      real(R8) , pointer :: duu10n      (:) ! diagnostic: 10m wind speed squared
-     real(R8) , pointer :: ocnsal      (:) ! ocean salinity
      real(R8) , pointer :: lwdn        (:) ! long  wave, downward
      real(R8) , pointer :: swdn        (:) ! short wave, downward
      real(R8) , pointer :: swup        (:) ! short wave, upward
@@ -87,10 +86,10 @@ contains
 !================================================================================
 
   subroutine med_phases_aofluxes_init(gcomp, aoflux, rc)
-    use ESMF, only : ESMF_GridComp, ESMF_VM, ESMF_VMGet, ESMF_GridCompGet
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGERR_PASSTHRU
-    use ESMF, only : ESMF_SUCCESS, ESMF_LogFoundError
-    use NUOPC, only : NUOPC_CompAttributeGet
+    use ESMF                  , only : ESMF_GridComp, ESMF_VM, ESMF_VMGet, ESMF_GridCompGet
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGERR_PASSTHRU
+    use ESMF                  , only : ESMF_SUCCESS, ESMF_LogFoundError
+    use NUOPC                 , only : NUOPC_CompAttributeGet
     use esmFlds               , only : flds_scalar_name
     use esmFlds               , only : flds_scalar_num
     use esmFlds               , only : fldListMed_aoflux_o
@@ -99,7 +98,7 @@ contains
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_init
     use shr_nuopc_fldList_mod , only : shr_nuopc_fldlist_getfldnames
-    use med_constants_mod, only : CL
+    use med_constants_mod     , only : CL
     ! Initialize ocn/atm flux calculations
 
     ! input/output variables
@@ -299,7 +298,6 @@ contains
     use ESMF                  , only : operator(==), ESMF_GEOMTYPE_MESH
     use NUOPC                 , only : NUOPC_CompAttributeGet
     use med_constants_mod     , only : CL, CX
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_getFieldN
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
 
@@ -318,25 +316,25 @@ contains
     integer                , intent(out)   :: rc
     !
     ! Local variables
-    type(ESMF_VM)               :: vm
-    integer                     :: iam
-    type(ESMF_Field)            :: lfield
-    type(ESMF_Grid)             :: lgrid
-    type(ESMF_Mesh)             :: lmesh
-    type(ESMF_GeomType_Flag)    :: geomtype
-    integer                     :: n
-    integer                     :: lsize
-    real(R8), pointer :: ofrac(:)
-    real(R8), pointer :: ifrac(:)
-    integer                     :: dimCount
-    integer                     :: spatialDim
-    integer                     :: numOwnedElements
-    character(CL)               :: cvalue
-    real(R8), pointer :: ownedElemCoords(:)
+    type(ESMF_VM)            :: vm
+    integer                  :: iam
+    type(ESMF_Field)         :: lfield
+    type(ESMF_Grid)          :: lgrid
+    type(ESMF_Mesh)          :: lmesh
+    type(ESMF_GeomType_Flag) :: geomtype
+    integer                  :: n
+    integer                  :: lsize
+    real(R8), pointer        :: ofrac(:)
+    real(R8), pointer        :: ifrac(:)
+    integer                  :: dimCount
+    integer                  :: spatialDim
+    integer                  :: numOwnedElements
+    character(CL)            :: cvalue
+    real(R8), pointer        :: ownedElemCoords(:)
     character(*),parameter   :: subName =   '(med_aofluxes_init) '
-    logical       :: flds_wiso  ! use case
-    integer :: dbrc
-    character(len=CX)            :: tmpstr
+    logical                  :: flds_wiso  ! use case
+    integer                  :: dbrc
+    character(len=CX)        :: tmpstr
     !-----------------------------------------------------------------------
 
     if (dbug_flag > 5) then
@@ -429,8 +427,6 @@ contains
     call shr_nuopc_methods_FB_GetFldPtr(FBOcn, fldname='So_u', fldptr1=aoflux%uocn, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_nuopc_methods_FB_GetFldPtr(FBOcn, fldname='So_v', fldptr1=aoflux%vocn, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(FBOcn, fldname='So_s', fldptr1=aoflux%ocnsal, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (flds_wiso) then
        call shr_nuopc_methods_FB_GetFldPtr(FBOcn, fldname='So_roce_16O', fldptr1=aoflux%roce_16O, rc=rc)

--- a/src/drivers/nuopc/shr/med_constants_mod.F90
+++ b/src/drivers/nuopc/shr/med_constants_mod.F90
@@ -4,15 +4,15 @@ module med_constants_mod
   ! Mediator Internal State Datatype.
   !-----------------------------------------------------------------------------
 
-  use shr_kind_mod, only : R8=>SHR_KIND_R8
-  use shr_kind_mod, only : R4=>SHR_KIND_R4
-  use shr_kind_mod, only : CL=>SHR_KIND_CL
-  use shr_kind_mod, only : CS=>SHR_KIND_CS
-  use shr_kind_mod, only : CX=>SHR_KIND_CX
-  use shr_kind_mod, only : IN=>SHR_KIND_IN
-  use shr_kind_mod, only : I8=>SHR_KIND_I8
-  use shr_cal_mod, only: med_constants_noleap => shr_cal_noleap
-  use shr_cal_mod, only: med_constants_gregorian => shr_cal_gregorian
+  use shr_kind_mod   , only : R8=>SHR_KIND_R8
+  use shr_kind_mod   , only : R4=>SHR_KIND_R4
+  use shr_kind_mod   , only : CL=>SHR_KIND_CL
+  use shr_kind_mod   , only : CS=>SHR_KIND_CS
+  use shr_kind_mod   , only : CX=>SHR_KIND_CX
+  use shr_kind_mod   , only : IN=>SHR_KIND_IN
+  use shr_kind_mod   , only : I8=>SHR_KIND_I8
+  use shr_cal_mod    , only : med_constants_noleap => shr_cal_noleap
+  use shr_cal_mod    , only : med_constants_gregorian => shr_cal_gregorian
 
   implicit none
 

--- a/src/drivers/nuopc/shr/med_constants_mod.F90
+++ b/src/drivers/nuopc/shr/med_constants_mod.F90
@@ -1,18 +1,30 @@
 module med_constants_mod
 
   !-----------------------------------------------------------------------------
-  ! Mediator Internal State Datatype.
+  ! Used by all components and mediator
   !-----------------------------------------------------------------------------
 
   use shr_kind_mod   , only : R8=>SHR_KIND_R8
   use shr_kind_mod   , only : R4=>SHR_KIND_R4
+  use shr_kind_mod   , only : IN=>SHR_KIND_IN
+  use shr_kind_mod   , only : I8=>SHR_KIND_I8
   use shr_kind_mod   , only : CL=>SHR_KIND_CL
   use shr_kind_mod   , only : CS=>SHR_KIND_CS
   use shr_kind_mod   , only : CX=>SHR_KIND_CX
-  use shr_kind_mod   , only : IN=>SHR_KIND_IN
-  use shr_kind_mod   , only : I8=>SHR_KIND_I8
+  use shr_kind_mod   , only : CXX=>SHR_KIND_CXX
+
   use shr_cal_mod    , only : med_constants_noleap => shr_cal_noleap
   use shr_cal_mod    , only : med_constants_gregorian => shr_cal_gregorian
+  use shr_log_mod    , only : shr_log_Unit
+  use shr_cal_mod    , only : shr_cal_ymd2date 
+  use shr_cal_mod    , only : shr_cal_noleap
+  use shr_cal_mod    , only : shr_cal_gregorian
+  use shr_file_mod   , only : shr_file_getlogunit
+  use shr_file_mod   , only : shr_file_setlogunit
+  use shr_file_mod   , only : shr_file_getloglevel
+  use shr_file_mod   , only : shr_file_setloglevel
+  use shr_file_mod   , only : shr_file_getUnit
+  use shr_file_mod   , only : shr_file_setIO
 
   implicit none
 

--- a/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
@@ -4,18 +4,13 @@ module shr_nuopc_methods_mod
   ! Generic operation methods used by the Mediator Component.
   !-----------------------------------------------------------------------------
 
-  use shr_kind_mod, only : R8=>shr_kind_r8
-  use ESMF, only : ESMF_GeomType_Flag, ESMF_FieldStatus_Flag, ESMF_PoleMethod_Flag
-  use ESMF, only: operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
-  use ESMF, only: operator(<=), operator(>), operator(==)
-  use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
-  use ESMF, only : ESMF_LOGERR_PASSTHRU, ESMF_LogFoundError, ESMF_LOGMSG_ERROR
-  use ESMF, only : ESMF_MAXSTR, ESMF_LOGMSG_WARNING, ESMF_POLEMETHOD_ALLAVG
-  use med_constants_mod, only : dbug_flag => med_constants_dbug_flag
-  use med_constants_mod, only : czero => med_constants_czero
-  use med_constants_mod, only : spval => med_constants_spval
-  use med_constants_mod, only : spval_init => med_constants_spval_init
-  use med_constants_mod, only : ispval_mask => med_constants_ispval_mask
+  use ESMF              , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
+  use ESMF              , only : operator(<=), operator(>), operator(==)
+  use ESMF              , only : ESMF_GeomType_Flag, ESMF_FieldStatus_Flag, ESMF_PoleMethod_Flag
+  use ESMF              , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF              , only : ESMF_LOGERR_PASSTHRU, ESMF_LogFoundError, ESMF_LOGMSG_ERROR
+  use ESMF              , only : ESMF_MAXSTR, ESMF_LOGMSG_WARNING, ESMF_POLEMETHOD_ALLAVG
+  use med_constants_mod , only : dbug_flag => med_constants_dbug_flag
 
   implicit none
   private
@@ -199,11 +194,13 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_FB_init(FBout, flds_scalar_name, fieldNameList, FBgeom, STgeom, FBflds, STflds, name, rc)
-    use ESMF, only : ESMF_Field, ESMF_FieldBundle, ESMF_FieldBundleCreate, ESMF_FieldBundleGet
-    use ESMF, only : ESMF_State, ESMF_Grid, ESMF_Mesh, ESMF_StaggerLoc, ESMF_MeshLoc
-    use ESMF, only : ESMF_StateGet, ESMF_FieldGet, ESMF_FieldBundleAdd, ESMF_FieldCreate
-    use ESMF, only : ESMF_TYPEKIND_R8, ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID
-    use ESMF, only : ESMF_FIELDSTATUS_EMPTY
+    use ESMF              , only : ESMF_Field, ESMF_FieldBundle, ESMF_FieldBundleCreate, ESMF_FieldBundleGet
+    use ESMF              , only : ESMF_State, ESMF_Grid, ESMF_Mesh, ESMF_StaggerLoc, ESMF_MeshLoc
+    use ESMF              , only : ESMF_StateGet, ESMF_FieldGet, ESMF_FieldBundleAdd, ESMF_FieldCreate
+    use ESMF              , only : ESMF_TYPEKIND_R8, ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID
+    use ESMF              , only : ESMF_FIELDSTATUS_EMPTY
+    use med_constants_mod , only : spval_init => med_constants_spval_init
+
     ! ----------------------------------------------
     ! Create FBout from fieldNameList, FBflds, STflds, FBgeom or STgeom in that order or priority
     ! Pass in FBgeom OR STgeom, get grid/mesh from that object
@@ -473,7 +470,7 @@ module shr_nuopc_methods_mod
     ! local variables
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
-    integer :: dbrc
+    integer                         :: dbrc
     character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_getNameN)'
     ! ----------------------------------------------
 
@@ -511,6 +508,7 @@ module shr_nuopc_methods_mod
 
   subroutine shr_nuopc_methods_FB_getFieldN(FB, fieldnum, field, rc)
     use ESMF, only : ESMF_Field, ESMF_FieldBundle, ESMF_FieldBundleGet
+
     ! ----------------------------------------------
     ! Get field number fieldnum out of FB
     ! ----------------------------------------------
@@ -521,7 +519,7 @@ module shr_nuopc_methods_mod
 
     ! local variables
     character(len=ESMF_MAXSTR) :: name
-    integer :: dbrc
+    integer                    :: dbrc
     character(len=*),parameter :: subname='(shr_nuopc_methods_FB_getFieldN)'
     ! ----------------------------------------------
 
@@ -588,7 +586,7 @@ module shr_nuopc_methods_mod
     ! local variables
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
-    integer :: dbrc
+    integer                         :: dbrc
     character(len=*),parameter      :: subname='(shr_nuopc_methods_State_getNameN)'
     ! ----------------------------------------------
 
@@ -625,9 +623,9 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_State_getNumFields(State, fieldnum, rc)
-    use NUOPC, only : NUOPC_GetStateMemberLists
-    use ESMF, only : ESMF_State, ESMF_Field, ESMF_StateGet, ESMF_STATEITEM_FIELD
-    use ESMF, only : ESMF_StateItem_Flag
+    use NUOPC , only : NUOPC_GetStateMemberLists
+    use ESMF  , only : ESMF_State, ESMF_Field, ESMF_StateGet, ESMF_STATEITEM_FIELD
+    use ESMF  , only : ESMF_StateItem_Flag
     ! ----------------------------------------------
     ! Get field number fieldnum name out of State
     ! ----------------------------------------------
@@ -640,7 +638,7 @@ module shr_nuopc_methods_mod
     type(ESMF_Field), pointer          :: fieldList(:)
     type(ESMF_StateItem_Flag), pointer :: itemTypeList(:)
     logical, parameter                 :: use_NUOPC_method = .true.
-    integer :: dbrc
+    integer                            :: dbrc
     character(len=*),parameter         :: subname='(shr_nuopc_methods_State_getNumFields)'
     ! ----------------------------------------------
 
@@ -758,7 +756,7 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Destroy fields in FB and FB
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_FieldBundle, ESMF_FieldBundleGet, ESMF_FieldDestroy
     use ESMF, only : ESMF_FieldBundleDestroy, ESMF_Field
 
@@ -807,8 +805,10 @@ module shr_nuopc_methods_mod
     ! Set all fields to value in FB
     ! If value is not provided, reset to 0.0
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
-    use ESMF, only : ESMF_FieldBundle, ESMF_FieldBundleGet
+    use med_constants_mod , only : czero => med_constants_czero
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_FieldBundle, ESMF_FieldBundleGet
+
     type(ESMF_FieldBundle), intent(inout)        :: FB
     real(R8)    , intent(in), optional :: value
     integer               , intent(out)          :: rc
@@ -854,7 +854,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_FB_FieldCopy(FBin,fldin,FBout,fldout,rc)
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_FieldBundle, ESMF_FAILURE, ESMF_LOGMSG_ERROR
     ! ----------------------------------------------
     ! Copy a field in a field bundle to another field in a field bundle
@@ -1173,34 +1173,37 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Supports up to a five way merge
     ! ----------------------------------------------
-    use ESMF, only : ESMF_FieldBundle
-    type(ESMF_FieldBundle), intent(inout)                 :: FBout
-    character(len=*)      , intent(in)                    :: fnameout
-    type(ESMF_FieldBundle), intent(in), optional          :: FBinA
-    character(len=*)      , intent(in), optional          :: fnameA
-    real(R8)    , intent(in), optional, pointer :: wgtA(:,:)
-    type(ESMF_FieldBundle), intent(in), optional          :: FBinB
-    character(len=*)      , intent(in), optional          :: fnameB
-    real(R8)    , intent(in), optional, pointer :: wgtB(:,:)
-    type(ESMF_FieldBundle), intent(in), optional          :: FBinC
-    character(len=*)      , intent(in), optional          :: fnameC
-    real(R8)    , intent(in), optional, pointer :: wgtC(:,:)
-    type(ESMF_FieldBundle), intent(in), optional          :: FBinD
-    character(len=*)      , intent(in), optional          :: fnameD
-    real(R8)    , intent(in), optional, pointer :: wgtD(:,:)
-    type(ESMF_FieldBundle), intent(in), optional          :: FBinE
-    character(len=*)      , intent(in), optional          :: fnameE
-    real(R8)    , intent(in), optional, pointer :: wgtE(:,:)
-    integer               , intent(out)                   :: rc
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_FieldBundle
+    use med_constants_mod , only : czero => med_constants_czero
+
+    type(ESMF_FieldBundle), intent(inout)        :: FBout
+    character(len=*)      , intent(in)           :: fnameout
+    type(ESMF_FieldBundle), intent(in), optional :: FBinA
+    character(len=*)      , intent(in), optional :: fnameA
+    real(R8)    , intent(in), optional, pointer  :: wgtA(:,:)
+    type(ESMF_FieldBundle), intent(in), optional :: FBinB
+    character(len=*)      , intent(in), optional :: fnameB
+    real(R8)    , intent(in), optional, pointer  :: wgtB(:,:)
+    type(ESMF_FieldBundle), intent(in), optional :: FBinC
+    character(len=*)      , intent(in), optional :: fnameC
+    real(R8)    , intent(in), optional, pointer  :: wgtC(:,:)
+    type(ESMF_FieldBundle), intent(in), optional :: FBinD
+    character(len=*)      , intent(in), optional :: fnameD
+    real(R8)    , intent(in), optional, pointer  :: wgtD(:,:)
+    type(ESMF_FieldBundle), intent(in), optional :: FBinE
+    character(len=*)      , intent(in), optional :: fnameE
+    real(R8)    , intent(in), optional, pointer  :: wgtE(:,:)
+    integer               , intent(out)          :: rc
 
     ! local variables
-    real(R8), pointer :: dataOut(:,:)
-    real(R8), pointer :: dataPtr(:,:)
-    real(R8), pointer :: wgt(:,:)
-    integer                     :: lb1,ub1,lb2,ub2,i,j,n
-    logical                     :: wgtfound, FBinfound
-    integer :: dbrc
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_FB_FieldMerge_2D)'
+    real(R8), pointer          :: dataOut(:,:)
+    real(R8), pointer          :: dataPtr(:,:)
+    real(R8), pointer          :: wgt(:,:)
+    integer                    :: lb1,ub1,lb2,ub2,i,j,n
+    logical                    :: wgtfound, FBinfound
+    integer                    :: dbrc
+    character(len=*),parameter :: subname='(shr_nuopc_methods_FB_FieldMerge_2D)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1359,8 +1362,9 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Supports up to a five way merge
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => SHR_KIND_R8
-    use ESMF, only : ESMF_FieldBundle
+    use med_constants_mod , only : R8
+    use med_constants_mod , only : czero => med_constants_czero
+    use ESMF              , only : ESMF_FieldBundle
 
     type(ESMF_FieldBundle), intent(inout)                 :: FBout
     character(len=*)      , intent(in)                    :: fnameout
@@ -1538,12 +1542,13 @@ module shr_nuopc_methods_mod
     ! Set all fields to value in State
     ! If value is not provided, reset to 0.0
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
-    use ESMF, only : ESMF_State, ESMF_StateGet
+    use med_constants_mod , only : czero => med_constants_czero
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_State, ESMF_StateGet
 
-    type(ESMF_State)  , intent(inout)        :: State
-    real(R8), intent(in), optional :: value
-    integer           , intent(out)          :: rc
+    type(ESMF_State) , intent(inout)        :: State
+    real(R8)         , intent(in), optional :: value
+    integer          , intent(out)          :: rc
 
     ! local variables
     integer                         :: i,j,n
@@ -1589,8 +1594,8 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Set all fields to zero in FB
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
-    use ESMF, only : ESMF_FieldBundle, ESMF_FieldBundleGet
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_FieldBundle, ESMF_FieldBundleGet
 
     type(ESMF_FieldBundle), intent(inout) :: FB
     integer               , intent(in)    :: count
@@ -1600,9 +1605,9 @@ module shr_nuopc_methods_mod
     integer                         :: i,j,n
     integer                         :: fieldCount, lrank
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
-    real(R8), pointer     :: dataPtr1(:)
-    real(R8), pointer     :: dataPtr2(:,:)
-    integer :: dbrc
+    real(R8), pointer               :: dataPtr1(:)
+    real(R8), pointer               :: dataPtr2(:,:)
+    integer                         :: dbrc
     character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_average)'
     ! ----------------------------------------------
 
@@ -1666,21 +1671,21 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Diagnose status of FB
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
-    use ESMF, only : ESMF_FieldBundle, ESMF_FieldBundleGet
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_FieldBundle, ESMF_FieldBundleGet
 
-    type(ESMF_FieldBundle), intent(inout) :: FB
-    character(len=*)      , intent(in), optional :: string
-    integer               , intent(out)   :: rc
+    type(ESMF_FieldBundle) , intent(inout)        :: FB
+    character(len=*)       , intent(in), optional :: string
+    integer                , intent(out)          :: rc
 
     ! local variables
     integer                         :: i,j,n
     integer                         :: fieldCount, lrank
     character(ESMF_MAXSTR), pointer :: lfieldnamelist(:)
     character(len=64)               :: lstring
-    real(R8), pointer     :: dataPtr1d(:)
-    real(R8), pointer     :: dataPtr2d(:,:)
-    integer :: dbrc
+    real(R8), pointer               :: dataPtr1d(:)
+    real(R8), pointer               :: dataPtr2d(:,:)
+    integer                         :: dbrc
     character(len=*), parameter     :: subname='(shr_nuopc_methods_FB_diagnose)'
     ! ----------------------------------------------
 
@@ -1756,7 +1761,7 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Diagnose status of Array
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_Array, ESMF_ArrayGet
 
     type(ESMF_Array), intent(inout)        :: array
@@ -1805,7 +1810,7 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Diagnose status of State
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_State, ESMF_StateGet
 
     type(ESMF_State), intent(in)           :: State
@@ -1891,7 +1896,7 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Diagnose status of State
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_FieldBundle
 
     type(ESMF_FieldBundle), intent(inout)  :: FB
@@ -2048,8 +2053,9 @@ module shr_nuopc_methods_mod
     ! Accumulate common field names from FBin to FBout
     ! If copy is passed in and true, the this is a copy
     ! ----------------------------------------------
-    use ESMF, only : ESMF_FieldBundle
-    use ESMF, only : ESMF_FieldBundleGet
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_FieldBundle
+    use ESMF              , only : ESMF_FieldBundleGet
 
     type(ESMF_FieldBundle), intent(inout) :: FBout
     type(ESMF_FieldBundle), intent(in)    :: FBin
@@ -2057,15 +2063,15 @@ module shr_nuopc_methods_mod
     integer               , intent(out)   :: rc
 
     ! local variables
-    integer                     :: i,j,n
-    integer                     :: fieldCount, lranki, lranko
-    character(ESMF_MAXSTR) ,pointer  :: lfieldnamelist(:)
-    logical                     :: exists
-    logical                     :: lcopy
-    real(R8), pointer :: dataPtri1(:)  , dataPtro1(:)
-    real(R8), pointer :: dataPtri2(:,:), dataPtro2(:,:)
-    integer :: dbrc
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_accumFB2FB)'
+    integer                         :: i,j,n
+    integer                         :: fieldCount, lranki, lranko
+    character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
+    logical                         :: exists
+    logical                         :: lcopy
+    real(R8), pointer               :: dataPtri1(:)  , dataPtro1(:)
+    real(R8), pointer               :: dataPtri2(:,:), dataPtro2(:,:)
+    integer                         :: dbrc
+    character(len=*), parameter     :: subname='(shr_nuopc_methods_FB_accumFB2FB)'
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -2162,7 +2168,7 @@ module shr_nuopc_methods_mod
     ! Accumulate common field names from State to FB
     ! If copy is passed in and true, the this is a copy
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_State, ESMF_FieldBundle
     use ESMF, only : ESMF_StateGet, ESMF_FieldBundleGet
     use ESMF, only : ESMF_STATEITEM_NOTFOUND, ESMF_StateItem_Flag
@@ -2281,9 +2287,10 @@ module shr_nuopc_methods_mod
     ! Accumulate common field names from FB to State
     ! If copy is passed in and true, the this is a copy
     ! ----------------------------------------------
-    use ESMF, only : ESMF_State, ESMF_FieldBundle
-    use ESMF, only : ESMF_StateGet, ESMF_FieldBundleGet
-    use ESMF, only : ESMF_STATEITEM_NOTFOUND, ESMF_StateItem_Flag
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_State, ESMF_FieldBundle
+    use ESMF              , only : ESMF_StateGet, ESMF_FieldBundleGet
+    use ESMF              , only : ESMF_STATEITEM_NOTFOUND, ESMF_StateItem_Flag
 
     type(ESMF_State)      , intent(inout) :: STout
     type(ESMF_FieldBundle), intent(in)    :: FBin
@@ -2432,22 +2439,22 @@ module shr_nuopc_methods_mod
     ! abort is true by default and will abort if fldptr is not yet allocated in field
     ! rank returns 0, 1, or 2.  0 means fldptr not allocated and abort=false
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8=>shr_kind_r8
-    use ESMF, only : ESMF_Field,ESMF_Mesh, ESMF_FieldGet, ESMF_MeshGet
-    use ESMF, only : ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID, ESMF_FIELDSTATUS_COMPLETE
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_Field,ESMF_Mesh, ESMF_FieldGet, ESMF_MeshGet
+    use ESMF              , only : ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID, ESMF_FIELDSTATUS_COMPLETE
 
-    type(ESMF_Field)           , intent(in)              :: field
-    real(R8), pointer, intent(inout), optional :: fldptr1(:)
-    real(R8), pointer, intent(inout), optional :: fldptr2(:,:)
-    integer                    , intent(out)  , optional :: rank
-    logical                    , intent(in)   , optional :: abort
-    integer                    , intent(out)  , optional :: rc
+    type(ESMF_Field)  , intent(in)              :: field
+    real(R8), pointer , intent(inout), optional :: fldptr1(:)
+    real(R8), pointer , intent(inout), optional :: fldptr2(:,:)
+    integer           , intent(out)  , optional :: rank
+    logical           , intent(in)   , optional :: abort
+    integer           , intent(out)  , optional :: rc
 
     ! local variables
-    type(ESMF_Mesh)            :: lmesh
-    integer                    :: lrank, nnodes, nelements
-    logical                    :: labort
-    integer :: dbrc
+    type(ESMF_Mesh) :: lmesh
+    integer         :: lrank, nnodes, nelements
+    logical         :: labort
+    integer         :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_Field_GetFldPtr)'
     ! ----------------------------------------------
 
@@ -2547,22 +2554,23 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_FB_GetFldPtr(FB, fldname, fldptr1, fldptr2, rank, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
-    use ESMF, only : ESMF_FieldBundle, ESMF_FieldBundleGet, ESMF_Field
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_FieldBundle, ESMF_FieldBundleGet, ESMF_Field
+
     ! ----------------------------------------------
     ! Get pointer to a field bundle field
     ! ----------------------------------------------
-    type(ESMF_FieldBundle),      intent(in)              :: FB
-    character(len=*)      ,      intent(in)              :: fldname
-    real(R8), pointer, intent(inout), optional :: fldptr1(:)
-    real(R8), pointer, intent(inout), optional :: fldptr2(:,:)
-    integer               ,      intent(out),   optional :: rank
-    integer               ,      intent(out),   optional :: rc
+    type(ESMF_FieldBundle) , intent(in)              :: FB
+    character(len=*)       , intent(in)              :: fldname
+    real(R8), pointer      , intent(inout), optional :: fldptr1(:)
+    real(R8), pointer      , intent(inout), optional :: fldptr2(:,:)
+    integer                , intent(out),   optional :: rank
+    integer                , intent(out),   optional :: rc
 
     ! local variables
-    type(ESMF_Field)           :: lfield
-    integer                    :: lrank
-    integer :: dbrc
+    type(ESMF_Field) :: lfield
+    integer          :: lrank
+    integer          :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_FB_GetFldPtr)'
     ! ----------------------------------------------
 
@@ -2606,7 +2614,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_FB_SetFldPtr(FB, fldname, val, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_FieldBundle, ESMF_Field
 
     type(ESMF_FieldBundle), intent(in)  :: FB
@@ -2655,7 +2663,7 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Get pointer to a state field
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_State, ESMF_Field, ESMF_StateGet
 
     type(ESMF_State),            intent(in)              :: ST
@@ -2705,7 +2713,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_State_SetFldPtr(ST, fldname, val, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_State, ESMF_Field
 
     type(ESMF_State)  , intent(in)  :: ST
@@ -2751,7 +2759,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   logical function shr_nuopc_methods_FieldPtr_Compare1(fldptr1, fldptr2, cstring, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     real(R8), pointer, intent(in)  :: fldptr1(:)
     real(R8), pointer, intent(in)  :: fldptr2(:)
     character(len=*)           , intent(in)  :: cstring
@@ -2788,7 +2796,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   logical function shr_nuopc_methods_FieldPtr_Compare2(fldptr1, fldptr2, cstring, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     real(R8), pointer, intent(in)  :: fldptr1(:,:)
     real(R8), pointer, intent(in)  :: fldptr2(:,:)
     character(len=*)           , intent(in)  :: cstring
@@ -2899,7 +2907,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_Field_GeomPrint(field, string, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_Field, ESMF_Grid, ESMF_Mesh
     use ESMF, only : ESMF_FieldGet, ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID, ESMF_FIELDSTATUS_EMPTY
 
@@ -3058,7 +3066,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_Grid_Print(grid, string, rc)
-    use shr_kind_mod, only : R8 => shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_Grid, ESMF_DistGrid, ESMF_StaggerLoc
     use ESMF, only : ESMF_GridGet, ESMF_DistGridGet, ESMF_GridGetCoord
     use ESMF, only : ESMF_STAGGERLOC_CENTER, ESMF_STAGGERLOC_CORNER
@@ -3255,7 +3263,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_Mesh_Write(mesh, string, rc)
-    use shr_kind_mod, only : R8=>shr_kind_r8
+    use med_constants_mod, only : R8
     use ESMF, only : ESMF_Mesh, ESMF_MeshGet, ESMF_Array, ESMF_ArrayWrite, ESMF_DistGrid
 
     type(ESMF_Mesh) ,intent(in)  :: mesh
@@ -3712,27 +3720,31 @@ module shr_nuopc_methods_mod
 !================================================================================
 
   subroutine shr_nuopc_methods_State_GetScalar(State, scalar_id, value, mpicom, flds_scalar_name, flds_scalar_num, rc)
-    use mpi, only :  mpi_comm_rank, mpi_bcast, MPI_REAL8
-    use ESMF, only : ESMF_SUCCESS, ESMF_State, ESMF_StateGet, ESMF_Field, ESMF_FieldGet
-    use ESMF, only : ESMF_FAILURE, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_LogWrite
-    use ESMF, only : ESMF_LOGMSG_INFO
+    use med_constants_mod , only : R8
+   !use mpi               , only : mpi_comm_rank, MPI_REAL8, mpi_bcast !TODO: mpi_bcast use does not seem to work on hobart
+    use mpi
+    use ESMF              , only : ESMF_SUCCESS, ESMF_State, ESMF_StateGet, ESMF_Field, ESMF_FieldGet
+    use ESMF              , only : ESMF_FAILURE, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_LogWrite
+    use ESMF              , only : ESMF_LOGMSG_INFO
+
     ! ----------------------------------------------
     ! Get scalar data from State for a particular name and broadcast it to all other pets
     ! in mpicom
     ! ----------------------------------------------
-    type(ESMF_State),  intent(in)     :: State
-    integer,           intent(in)     :: scalar_id
-    real(R8),intent(out)    :: value
-    integer,           intent(in)     :: mpicom
-    character(len=*),  intent(in)     :: flds_scalar_name
-    integer,           intent(in)     :: flds_scalar_num
-    integer,           intent(inout)  :: rc
+
+    type(ESMF_State), intent(in)     :: State
+    integer,          intent(in)     :: scalar_id
+    real(R8),         intent(out)    :: value
+    integer,          intent(in)     :: mpicom
+    character(len=*), intent(in)     :: flds_scalar_name
+    integer,          intent(in)     :: flds_scalar_num
+    integer,          intent(inout)  :: rc
 
     ! local variables
-    integer :: mytask, ierr, len
-    type(ESMF_Field) :: field
+    integer           :: mytask, ierr, len
+    type(ESMF_Field)  :: field
     real(R8), pointer :: farrayptr(:,:)
-    integer :: dbrc
+    integer           :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_State_GetScalar)'
 
     rc = ESMF_SUCCESS
@@ -3764,22 +3776,23 @@ module shr_nuopc_methods_mod
     ! ----------------------------------------------
     ! Set scalar data from State for a particular name
     ! ----------------------------------------------
-    use shr_kind_mod, only : R8=>shr_kind_r8
-    use ESMF, only : ESMF_Field, ESMF_State, ESMF_StateGet, ESMF_FieldGet
-    use mpi, only : MPI_COMM_RANK
-    real(R8),intent(in)     :: value
-    integer,           intent(in)     :: scalar_id
-    type(ESMF_State),  intent(inout)  :: State
-    integer,           intent(in)     :: mpicom
-    character(len=*),  intent(in)     :: flds_scalar_name
-    integer,           intent(in)     :: flds_scalar_num
-    integer,           intent(inout)  :: rc
+    use med_constants_mod , only : R8
+    use ESMF              , only : ESMF_Field, ESMF_State, ESMF_StateGet, ESMF_FieldGet
+    use mpi               , only : MPI_COMM_RANK
+
+    real(R8),         intent(in)     :: value
+    integer,          intent(in)     :: scalar_id
+    type(ESMF_State), intent(inout)  :: State
+    integer,          intent(in)     :: mpicom
+    character(len=*), intent(in)     :: flds_scalar_name
+    integer,          intent(in)     :: flds_scalar_num
+    integer,          intent(inout)  :: rc
 
     ! local variables
-    integer :: mytask
-    type(ESMF_Field) :: field
+    integer           :: mytask
+    type(ESMF_Field)  :: field
     real(R8), pointer :: farrayptr(:,:)
-    integer :: dbrc
+    integer           :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_State_SetScalar)'
 
     rc = ESMF_SUCCESS
@@ -3805,17 +3818,17 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_State_UpdateTimestamp(state, time, rc)
-    use NUOPC, only : NUOPC_GetStateMemberLists
-    use ESMF, only : ESMF_State, ESMF_Time, ESMF_Field, ESMF_SUCCESS
+    use NUOPC , only : NUOPC_GetStateMemberLists
+    use ESMF  , only : ESMF_State, ESMF_Time, ESMF_Field, ESMF_SUCCESS
 
-    type(ESMF_State), intent(inout) :: state
-    type(ESMF_Time), intent(in)     :: time
-    integer, intent(out)  :: rc
+    type(ESMF_State) , intent(inout) :: state
+    type(ESMF_Time)  , intent(in)    :: time
+    integer          , intent(out)   :: rc
 
     ! local variables
-    integer :: i
-    type(ESMF_Field),pointer    :: fieldList(:)
-    integer :: dbrc
+    integer                  :: i
+    type(ESMF_Field),pointer :: fieldList(:)
+    integer                  :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_State_UpdateTimestamp)'
 
     rc = ESMF_SUCCESS
@@ -3834,12 +3847,13 @@ module shr_nuopc_methods_mod
 
   subroutine shr_nuopc_methods_Field_UpdateTimestamp(field, time, rc)
     use ESMF, only : ESMF_Field, ESMF_Time, ESMF_TimeGet, ESMF_AttributeSet, ESMF_ATTNEST_ON, ESMF_SUCCESS
-    type(ESMF_Field), intent(inout) :: field
-    type(ESMF_Time) , intent(in)    :: time
-    integer, intent(out)  :: rc
+
+    type(ESMF_Field) , intent(inout) :: field
+    type(ESMF_Time)  , intent(in)    :: time
+    integer          , intent(out)   :: rc
 
     ! local variables
-    integer               :: yy, mm, dd, h, m, s, ms, us, ns
+    integer :: yy, mm, dd, h, m, s, ms, us, ns
     integer :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_Field_UpdateTimestamp)'
 
@@ -3859,7 +3873,7 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   logical function shr_nuopc_methods_ChkErr(rc, line, file, mpierr)
-    use mpi, only : MPI_ERROR_STRING, MPI_MAX_ERROR_STRING, MPI_SUCCESS
+    use mpi , only : MPI_ERROR_STRING, MPI_MAX_ERROR_STRING, MPI_SUCCESS
     use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_LOGMSG_INFO
 
     integer, intent(in) :: rc
@@ -3889,9 +3903,10 @@ module shr_nuopc_methods_mod
   !-----------------------------------------------------------------------------
 
   subroutine shr_nuopc_methods_Print_FieldExchInfo(flag, values, logunit, fldlist, nflds, istr)
-    use shr_string_mod, only : shr_string_listGetName
-    use shr_kind_mod, only : R8 => shr_kind_r8
-    use ESMF, only : ESMF_MAXSTR
+    use shr_nuopc_utils_mod , only : shr_nuopc_string_listGetName
+    use med_constants_mod   , only : R8
+    use ESMF                , only : ESMF_MAXSTR
+
     ! !DESCRIPTION:
     ! Print out information about values to stdount
     ! - flag sets the level of information:
@@ -3901,18 +3916,18 @@ module shr_nuopc_methods_mod
 
 
     ! !INPUT/OUTPUT PARAMETERS:
-    integer            , intent(in)          :: flag  ! info level flag
-    real(R8) , intent(in)          :: values(:,:) ! arrays sent to/recieved from mediator
-    integer            , intent(in)          :: logunit
-    character(len=*)   , intent(in)          :: fldlist
-    integer            , intent(in)          :: nflds
-    character(*)       , intent(in),optional :: istr  ! string for print
+    integer          , intent(in)          :: flag  ! info level flag
+    real(R8)         , intent(in)          :: values(:,:) ! arrays sent to/recieved from mediator
+    integer          , intent(in)          :: logunit
+    character(len=*) , intent(in)          :: fldlist
+    integer          , intent(in)          :: nflds
+    character(*)     , intent(in),optional :: istr  ! string for print
 
     !--- local ---
     integer                    :: n           ! generic indicies
     integer                    :: nsize       ! grid point in values array
-    real(R8)         :: minl(nflds) ! local min
-    real(R8)         :: maxl(nflds) ! local max
+    real(R8)                   :: minl(nflds) ! local min
+    real(R8)                   :: maxl(nflds) ! local max
     character(len=ESMF_MAXSTR) :: name
 
     !--- formats ---
@@ -3936,7 +3951,7 @@ module shr_nuopc_methods_mod
        do n = 1, nflds
           minl(n) = minval(values(n,:))
           maxl(n) = maxval(values(n,:))
-          call shr_string_listGetName(fldlist, n, name)
+          call shr_nuopc_string_listGetName(fldlist, n, name)
           write(logunit,F03) 'l min/max ',minl(n),maxl(n),n,trim(name)
        enddo
     endif

--- a/src/drivers/nuopc/shr/shr_nuopc_scalars_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_scalars_mod.F90
@@ -1,0 +1,30 @@
+module shr_nuopc_scalars_mod
+  
+  !----------------------------------------------------------------------------
+  ! scalars
+  !----------------------------------------------------------------------------
+
+  implicit none
+  public
+
+  integer, parameter :: flds_scalar_index_nx                 = 1
+  integer, parameter :: flds_scalar_index_ny                 = 2
+  integer, parameter :: flds_scalar_index_precip_fact        = 3
+  integer, parameter :: flds_scalar_index_nextsw_cday        = 4
+  integer, parameter :: flds_scalar_index_dead_comps         = 5
+  integer, parameter :: flds_scalar_index_rofice_present     = 6  ! does rof have iceberg coupling on
+  integer, parameter :: flds_scalar_index_flood_present      = 7  ! does rof have flooding on
+  integer, parameter :: flds_scalar_index_ocnrof_prognostic  = 8  ! does ocn need rof data
+  integer, parameter :: flds_scalar_index_iceberg_prognostic = 9  ! does ice model support icebergs
+  integer, parameter :: flds_scalar_index_glclnd_present     = 10 ! does glc have land coupling fields on
+  integer, parameter :: flds_scalar_index_glcocn_present     = 11 ! does glc have ocean runoff on
+  integer, parameter :: flds_scalar_index_glcice_present     = 12 ! does glc have iceberg coupling on
+  integer, parameter :: flds_scalar_index_glc_valid_input    = 13 ! does glc have is valid accumulated data being sent to it?
+                                                                  ! (only valid of glc_prognostic is .true.)
+  integer, parameter :: flds_scalar_index_glc_coupled        = 14 ! does glc send fluxes to other components
+                                                                  ! (only relevant if glc_present is .true.)
+  integer, parameter :: flds_scalar_num                      = 14
+  character(len=*) , parameter :: flds_scalar_name = "cpl_scalars"
+
+
+end module shr_nuopc_scalars_mod

--- a/src/drivers/nuopc/shr/shr_nuopc_time_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_time_mod.F90
@@ -1,0 +1,439 @@
+module shr_nuopc_time_mod
+
+  ! !USES:
+  use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_Calendar, ESMF_Alarm 
+  use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
+  use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
+  use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate 
+  use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF                  , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
+  use ESMF                  , only : operator(<=), operator(>), operator(==)
+  use med_constants_mod     , only : CL
+  use shr_nuopc_utils_mod   , only : shr_nuopc_abort
+  use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+
+  implicit none
+  private    ! default private
+
+  public  :: shr_nuopc_time_alarmInit  ! initialize an alarm
+
+  private :: shr_nuopc_time_timeInit
+  private :: shr_nuopc_time_date2ymd
+
+  ! Clock and alarm options
+  character(len=*), private, parameter :: &
+       optNONE           = "none"      , &
+       optNever          = "never"     , &
+       optNSteps         = "nsteps"    , &
+       optNStep          = "nstep"     , &
+       optNSeconds       = "nseconds"  , &
+       optNSecond        = "nsecond"   , &
+       optNMinutes       = "nminutes"  , &
+       optNMinute        = "nminute"   , &
+       optNHours         = "nhours"    , &
+       optNHour          = "nhour"     , &
+       optNDays          = "ndays"     , &
+       optNDay           = "nday"      , &
+       optNMonths        = "nmonths"   , &
+       optNMonth         = "nmonth"    , &
+       optNYears         = "nyears"    , &
+       optNYear          = "nyear"     , &
+       optMonthly        = "monthly"   , &
+       optYearly         = "yearly"    , &
+       optDate           = "date"      , &
+       optIfdays0        = "ifdays0"   , &
+       optGLCCouplingPeriod = "glc_coupling_period"
+
+  ! Module data
+  integer, parameter          :: SecPerDay = 86400 ! Seconds per day
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine shr_nuopc_time_alarmInit( clock, alarm, option, &
+       opt_n, opt_ymd, opt_tod, RefTime, alarmname, rc)
+
+    ! !DESCRIPTION: Setup an alarm in a clock
+    ! Notes: The ringtime sent to AlarmCreate MUST be the next alarm
+    ! time.  If you send an arbitrary but proper ringtime from the
+    ! past and the ring interval, the alarm will always go off on the
+    ! next clock advance and this will cause serious problems.  Even
+    ! if it makes sense to initialize an alarm with some reference
+    ! time and the alarm interval, that reference time has to be
+    ! advance forward to be >= the current time.  In the logic below
+    ! we set an appropriate "NextAlarm" and then we make sure to
+    ! advance it properly based on the ring interval.
+
+    ! input/output variables
+    type(ESMF_Clock)            , intent(inout) :: clock     ! clock
+    type(ESMF_Alarm)            , intent(inout) :: alarm     ! alarm
+    character(len=*)            , intent(in)    :: option    ! alarm option
+    integer          , optional , intent(in)    :: opt_n     ! alarm freq
+    integer          , optional , intent(in)    :: opt_ymd   ! alarm ymd
+    integer          , optional , intent(in)    :: opt_tod   ! alarm tod (sec)
+    type(ESMF_Time)  , optional , intent(in)    :: RefTime   ! ref time
+    character(len=*) , optional , intent(in)    :: alarmname ! alarm name
+    integer                     , intent(inout) :: rc        ! Return code
+
+    ! local variables
+    type(ESMF_Calendar)     :: cal                ! calendar
+    integer                 :: lymd             ! local ymd
+    integer                 :: ltod             ! local tod
+    integer                 :: cyy,cmm,cdd,csec ! time info
+    integer                 :: nyy,nmm,ndd,nsec ! time info
+    character(len=64)       :: lalarmname       ! local alarm name
+    logical                 :: update_nextalarm ! update next alarm
+    type(ESMF_Time)         :: CurrTime         ! Current Time
+    type(ESMF_Time)         :: NextAlarm        ! Next restart alarm time
+    type(ESMF_TimeInterval) :: AlarmInterval    ! Alarm interval
+    character(len=*), parameter :: subname = '(shr_nuopc_time_alarmInit): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    lalarmname = 'alarm_unknown'
+    if (present(alarmname)) lalarmname = trim(alarmname)
+    ltod = 0
+    if (present(opt_tod)) ltod = opt_tod
+    lymd = -1
+    if (present(opt_ymd)) lymd = opt_ymd
+
+    call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_TimeGet(CurrTime, yy=cyy, mm=cmm, dd=cdd, s=csec, rc=rc )
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_TimeGet(CurrTime, yy=nyy, mm=nmm, dd=ndd, s=nsec, rc=rc )
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! initial guess of next alarm, this will be updated below 
+    if (present(RefTime)) then
+       NextAlarm = RefTime
+    else
+       NextAlarm = CurrTime
+    endif
+
+    ! Determine calendar
+    call ESMF_ClockGet(clock, calendar=cal)
+
+    write(6,*)'DEBUG: in alarm routine option = ',trim(option)
+
+    ! Determine inputs for call to create alarm
+    selectcase (trim(option))
+
+    case (optNONE)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
+
+    case (optNever)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
+
+    case (optDate)
+       if (.not. present(opt_ymd)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_ymd')
+       end if
+       if (lymd < 0 .or. ltod < 0) then
+          call shr_nuopc_abort(subname//trim(option)//'opt_ymd, opt_tod invalid')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call shr_nuopc_time_timeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate")
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
+
+    case (optIfdays0)
+       if (.not. present(opt_ymd)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_ymd')
+       end if
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0)  then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=opt_n, s=0, calendar=cal, rc=rc )
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .true.
+
+    case (optNSteps)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNStep)
+       if (.not.present(opt_n)) call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       if (opt_n <= 0)  call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNSeconds)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNSecond)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNMinutes)
+       call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNMinute)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNHours)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNHour)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNDays)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNDay)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNMonths)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNMonth)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optMonthly)
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=1, s=0, calendar=cal, rc=rc )
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .true.
+
+    case (optNYears)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNYear)
+       if (.not.present(opt_n)) then
+          call shr_nuopc_abort(subname//trim(option)//' requires opt_n')
+       end if
+       if (opt_n <= 0) then
+          call shr_nuopc_abort(subname//trim(option)//' invalid opt_n')
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optYearly)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .true.
+
+    case default
+       call shr_nuopc_abort(subname//'unknown option '//trim(option))
+
+    end select
+
+    ! --------------------------------------------------------------------------------
+    ! --- AlarmInterval and NextAlarm should be set ---
+    ! --------------------------------------------------------------------------------
+
+    ! --- advance Next Alarm so it won't ring on first timestep for
+    ! --- most options above. go back one alarminterval just to be careful
+
+    if (update_nextalarm) then
+       NextAlarm = NextAlarm - AlarmInterval
+       do while (NextAlarm <= CurrTime)
+          NextAlarm = NextAlarm + AlarmInterval
+       enddo
+    endif
+
+    alarm = ESMF_AlarmCreate( name=lalarmname, clock=clock, ringTime=NextAlarm, ringInterval=AlarmInterval, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine shr_nuopc_time_alarmInit
+
+  !===============================================================================
+
+  subroutine shr_nuopc_time_timeInit( Time, ymd, cal, tod, desc, logunit )
+
+    !  Create the ESMF_Time object corresponding to the given input time, given in
+    !  YMD (Year Month Day) and TOD (Time-of-day) format.
+    !  Set the time by an integer as YYYYMMDD and integer seconds in the day
+
+    ! input/output parameters:
+    type(ESMF_Time)     , intent(inout)        :: Time ! ESMF time
+    integer             , intent(in)           :: ymd  ! year, month, day YYYYMMDD
+    type(ESMF_Calendar) , intent(in)           :: cal  ! ESMF calendar
+    integer             , intent(in), optional :: tod  ! time of day in seconds
+    character(len=*)    , intent(in), optional :: desc ! description of time to set
+    integer             , intent(in), optional :: logunit
+
+    ! local varaibles
+    integer                     :: yr, mon, day ! Year, month, day as integers
+    integer                     :: ltod         ! local tod
+    character(CL)               :: ldesc        ! local desc
+    integer                     :: rc           ! return code
+    character(len=*), parameter :: subname = '(shr_nuopc_time_m_ETimeInit) '
+    !-------------------------------------------------------------------------------
+
+    ltod = 0
+    if (present(tod)) ltod = tod
+    ldesc = ''
+    if (present(desc)) ldesc = desc
+
+    if ( (ymd < 0) .or. (ltod < 0) .or. (ltod > SecPerDay) )then
+       if (present(logunit)) then
+          write(logunit,*) subname//': ERROR yymmdd is a negative number or '// &
+               'time-of-day out of bounds', ymd, ltod
+       end if
+       call shr_nuopc_abort( subname//'ERROR: Bad input' )
+    end if
+
+    call shr_nuopc_time_date2ymd (ymd,yr,mon,day)
+
+    call ESMF_TimeSet( Time, yy=yr, mm=mon, dd=day, s=ltod, calendar=cal, rc=rc )
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine shr_nuopc_time_timeInit
+
+  !===============================================================================
+
+  subroutine shr_nuopc_time_date2ymd (date, year, month, day)
+
+    ! input/output variables
+    integer, intent(in)  :: date             ! coded-date (yyyymmdd)
+    integer, intent(out) :: year,month,day   ! calendar year,month,day
+
+    ! local variables
+    integer :: tdate   ! temporary date
+    character(*),parameter :: subName = "(shr_nuopc_time_date2ymd)"
+    !-------------------------------------------------------------------------------
+
+    tdate = abs(date)
+    year = int(tdate/10000)
+    if (date < 0) then
+       year = -year
+    end if
+    month = int( mod(tdate,10000)/  100)
+    day = mod(tdate,  100)
+
+  end subroutine shr_nuopc_time_date2ymd
+
+end module shr_nuopc_time_mod

--- a/src/drivers/nuopc/shr/shr_nuopc_utils_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_utils_mod.F90
@@ -1,0 +1,9 @@
+module shr_nuopc_utils_mod
+
+  use shr_sys_mod    , only : shr_nuopc_abort => shr_sys_abort 
+  use shr_string_mod , only : shr_nuopc_string_listGetName => shr_string_listGetName
+
+  implicit none
+  public
+
+end module shr_nuopc_utils_mod


### PR DESCRIPTION
This PR demonstrates a new advertise/realize implementation that is totally self contained within datm
and no longer depends on shr_nuopc_fldlist data types.
It also eliminates all calls to seq_timemgr_mod from datm_comp_mod and atm_comp_nuopc.
These type of changes will be implemented in future PRs to the other CIME data models.

Test suite: ran the following tests and verified that they did not change answers relative to the head of nuopc_cmeps
ERS_Vmct_Ln5.f45_f45_mg37.I2000Clm50SpNuopc.hobart_intel
ERS_Vnuopc_Ln5.f45_f45_mg37.I2000Clm50SpNuopc.hobart_intel
ERS_Vnuopc_Ln10.T62_g16.CMOM.hobart_intel
Used mvertens/app_cesm-cmeps  UFSCOMP branch to carry this out
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 
User interface changes?: No
Update gh-pages html (Y/N)?:
Code review: 
