### PR TITLE
Fixes for bugs introduced in PR#20

### DIFF
--- a/scripts/testlist_cmeps.xml
+++ b/scripts/testlist_cmeps.xml
@@ -181,4 +181,185 @@
     </options>
   </test>
 
+
+  <test compset="BMOM" grid="f19_g16" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
+
+  <test compset="BMOM" grid="f19_g16" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
+
+  <test compset="CMOM" grid="T62_g16" name="ERS_Vnuopc_Ld5" testmods="mom/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="CMOM" grid="T62_g16" name="ERS_Vmct_Ld5" testmods="mom/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="GMOM" grid="T62_g16" name="ERS_Vnuopc_Ld5" testmods="mom/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="GMOM" grid="T62_g16" name="ERS_Vmct_Ld5" testmods="mom/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="DTEST" grid="T62_g37" name="ERS_Vnuopc_Ld5" testmods="cice/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="DTEST" grid="T62_g37" name="ERS_Vmct_Ld5" testmods="cice/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="F2000Nuopc" grid="f19_g16" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="F2000Nuopc" grid="f19_g16" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="X" grid="f19_g16" name="ERS_Vnuopc_Ln9">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="X" grid="f19_g16" name="ERS_Vmct_Ln9">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="A" grid="T31_g37_rx1" name="ERS_Vnuopc_Ln9">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="A" grid="T31_g37_rx1" name="ERS_Vmct_Ln9">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="ERS_Vnuopc_Ln5" testmods="clm/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="ERS_Vmct_Ln5" testmods="clm/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
 </testlist>

--- a/src/components/data_comps/datm/mct/atm_comp_mct.F90
+++ b/src/components/data_comps/datm/mct/atm_comp_mct.F90
@@ -192,7 +192,7 @@ CONTAINS
     ! Initialize datm
     !----------------------------------------------------------------------------
 
-    call datm_comp_init(Eclock, &
+    call datm_comp_init(&
          x2a=x2a, &
          a2x=a2x, &
          x2a_fields=seq_flds_x2a_fields, &
@@ -325,7 +325,6 @@ CONTAINS
     !--------------------------------
 
     call datm_comp_run(&
-         Eclock=EClock, &
          x2a=x2a, &
          a2x=a2x, &
          SDATM=SDATM, &

--- a/src/components/data_comps/datm/mct/atm_comp_mct.F90
+++ b/src/components/data_comps/datm/mct/atm_comp_mct.F90
@@ -178,15 +178,9 @@ CONTAINS
     !----------------------------------------------------------------------------
 
     call seq_timemgr_EClockGetData( EClock, &
-         curr_ymd=current_ymd, curr_tod=current_tod, curr_mon=current_mon, &
-         dtime=modeldt, stepno=stepno, calendar=calendar)
-
-    if (read_restart) then
-       nextsw_cday = datm_shr_getNextRadCDay( current_ymd, current_tod, stepno, modeldt, iradsw, calendar )
-    else
-       ! For a startup run the nextsw_cday is just the current calendar day
-       call seq_timemgr_EClockGetData( EClock, curr_cday=nextsw_cday)
-    endif
+         curr_ymd=current_ymd, curr_mon=current_mon, curr_tod=current_tod, &
+         stepno=stepno, dtime=modeldt, calendar=calendar)
+    nextsw_cday = datm_shr_getNextRadCDay( current_ymd, current_tod, stepno, modeldt, iradsw, calendar )
 
     !----------------------------------------------------------------------------
     ! Initialize datm

--- a/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
@@ -538,6 +538,12 @@ module atm_comp_nuopc
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !----------------------------------------------------------------------------
+    ! Set nextsw_cday
+    !----------------------------------------------------------------------------
+
+    nextsw_cday = datm_shr_getNextRadCDay( current_ymd, current_tod, stepno, modeldt, iradsw, calendar )
+
+    !----------------------------------------------------------------------------
     ! Initialize model
     !----------------------------------------------------------------------------
 
@@ -570,21 +576,6 @@ module atm_comp_nuopc
          current_tod, &
          current_mon, &
          atm_prognostic)
-
-    !----------------------------------------------------------------------------
-    ! Set nextsw_cday
-    !----------------------------------------------------------------------------
-
-    call NUOPC_CompAttributeGet(gcomp, name='read_restart', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) read_restart
-
-    if (read_restart) then
-       nextsw_cday = datm_shr_getNextRadCDay( current_ymd, current_tod, stepno, modeldt, iradsw, calendar )
-    else
-       ! For a startup run the nextsw_cday is just the current calendar day
-       call ESMF_TimeGet( currTime, dayofyear_r8=nextsw_cday, rc=rc )
-    endif
 
     !--------------------------------
     ! Generate the mesh

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -232,7 +232,7 @@ CONTAINS
     kv    = mct_aVect_indexRA(o2x,'So_v')
     kdhdx = mct_aVect_indexRA(o2x,'So_dhdx')
     kdhdy = mct_aVect_indexRA(o2x,'So_dhdy')
-    kswp  = mct_aVect_indexRA(o2x,'So_fswpen')
+    kswp  = mct_aVect_indexRA(o2x,'So_fswpen', perrwith='quiet') 
     kq    = mct_aVect_indexRA(o2x,'Fioo_q')
 
     call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=lsize)
@@ -441,7 +441,9 @@ CONTAINS
        o2x%rAttr(kdhdx,n) = 0.0_R8
        o2x%rAttr(kdhdy,n) = 0.0_R8
        o2x%rAttr(kq   ,n) = 0.0_R8
-       o2x%rAttr(kswp ,n) = swp
+       if (kswp /= 0) then
+          o2x%rAttr(kswp ,n) = swp
+       end if
     enddo
 
     ! NOTE: for SST_AQUAPANAL, the docn buildnml sets the stream to "null"
@@ -479,7 +481,9 @@ CONTAINS
           o2x%rAttr(kdhdx,n) = 0.0_R8
           o2x%rAttr(kdhdy,n) = 0.0_R8
           o2x%rAttr(kq   ,n) = 0.0_R8
-          o2x%rAttr(kswp ,n) = swp
+          if (kswp /= 0) then
+             o2x%rAttr(kswp ,n) = swp
+          end if
        enddo
 
     case('SST_AQUAPANAL')
@@ -508,7 +512,9 @@ CONTAINS
           o2x%rAttr(kdhdx,n) = 0.0_R8
           o2x%rAttr(kdhdy,n) = 0.0_R8
           o2x%rAttr(kq   ,n) = 0.0_R8
-          o2x%rAttr(kswp ,n) = swp
+          if (kswp /= 0) then
+             o2x%rAttr(kswp ,n) = swp
+          end if
        enddo
 
     case('IAF')
@@ -521,7 +527,9 @@ CONTAINS
           o2x%rAttr(kdhdx,n) = 0.0_R8
           o2x%rAttr(kdhdy,n) = 0.0_R8
           o2x%rAttr(kq   ,n) = 0.0_R8
-          o2x%rAttr(kswp ,n) = swp
+          if (kswp /= 0) then
+             o2x%rAttr(kswp ,n) = swp
+          end if
        enddo
 
     case('SOM')
@@ -621,7 +629,6 @@ CONTAINS
           write(logunit,F01)'export: ymd,tod,n,So_v       = ', target_ymd, target_tod, n, o2x%rattr(kv,n)    
           write(logunit,F01)'export: ymd,tod,n,So_dhdx    = ', target_ymd, target_tod, n, o2x%rattr(kdhdx,n)    
           write(logunit,F01)'export: ymd,tod,n,So_dhdy    = ', target_ymd, target_tod, n, o2x%rattr(kdhdy,n)    
-          write(logunit,F01)'export: ymd,tod,n,So_fswpen  = ', target_ymd, target_tod, n, o2x%rattr(kswp,n)    
           write(logunit,F01)'export: ymd,tod,n,Fioo_q     = ', target_ymd, target_tod, n, o2x%rattr(kq,n)    
        end do
     end if


### PR DESCRIPTION
Bugs were introduced in PR#20 due to insufficient testing
This PR resolves those bugs
This PR also brings in the new restart tests add to testlist_cmeps.xml in another PR#21 that can now be closed.

The following Externals.cfg file entries were used:

```
Checking status of externals: clm, fates, ptclm, mosart, cvmix, cime, cice, fms, fms, mom, mom, geokdtree, da_hooks, cam,
s   ./cime
        clean sandbox, mvertens/fix_bugs --> origin/nuopc-cmeps
    ./components/cam
        clean sandbox, on cam1/branch_tags/nuopc_cap_tags/nuopc_cap_n17_cam6_0_002/components/cam
    ./components/cice
        clean sandbox, on mvertens/nuopc_cap (5fd959e)
    ./components/clm
        clean sandbox, on mvertens/nuopc_cap (f36db6b)
    ./components/clm/src/fates
        clean sandbox, on fates_s1.8.1_a3.0.0
    ./components/clm/tools/PTCLM
        clean sandbox, on PTCLM2_180214
    ./components/mom
        clean sandbox, on 837470f1e4cc95605fd57acd00c2c3149fd7a2e8
    ./components/mom/MOM6
        clean sandbox, on 8fd077b35cc3e5fbc652a876feab81e351437899
    ./components/mom/MOM6/pkg/MOM6_DA_hooks
        clean sandbox, on 6d8834ca8cf399f1a0d202239d72919907f6cd74
    ./components/mom/MOM6/pkg/geoKdTree
        clean sandbox, on a4670b9743c883d310d821eeac5b1f77f587b9d5
    ./components/mosart
        clean sandbox, on mvertens/nuopc_cap
    ./libraries/CVMix
        clean sandbox, on v0.92-beta
    ./libraries/FMS
        clean sandbox, on 4a198e65401ba605e0fc44d1a2c0f4c9166dd6b4
    ./libraries/FMS/src
        clean sandbox, on warsaw_201803

```

Test suite: testlist_cmeps.xml
Test baseline: restart_cime5.6.8
Test namelist changes: Yes (namelist changes did occur but did not effect baselines)
Test status: bit for bit - except for the following failures:

```
    The following is a know failure and fails for the the baseline tests as well
    FAIL ERS_Vnuopc_Ld5.T62_g37.DTEST.cheyenne_intel.cice-nuopc_cap  COMPARE_base_rest

    NOTE: I suspect that this problem is coming from DOCN slab ocean restart problems -
    since with active ocean (i.e. GMOM) the restart test is passing.

    ---------------------------------------------------------------------
    the following actually are bfb with respect to the baselines - and
    also pass the restart tests but fail because there is non
    counterpart in the baseline directory for
    mom6.frc._0001_001.nc.base and mom6.sfc.day._0001_001.nc.base files.

    FAIL ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io RUN time=17
    FAIL ERR_Vmct_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io   COMPARE_base_rest
    FAIL ERS_Vmct_Ld5.T62_g16.CMOM.cheyenne_intel.mom-nuopc_cap            COMPARE_base_rest
    FAIL ERS_Vmct_Ld5.T62_g16.GMOM.cheyenne_intel.mom-nuopc_cap            COMPARE_base_rest
    FAIL ERS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel.mom-nuopc_cap          COMPARE_base_rest
    FAIL ERS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel.mom-nuopc_cap          COMPARE_base_rest
    FAIL ERS_Vmct_Ld5.T62_g16.GMOM.cheyenne_intel.mom-nuopc_cap            BASELINE restart_cime5.6.8
    FAIL ERS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel.mom-nuopc_cap          BASELINE restart_cime5.6.8

    ---------------------------------------------------------------------
    the baseline failures are only for the fields
      RMS ocnImp_Fioo_q                    5.0000E+01    NORMALIZED  1.2917E-01
      RMS iceExp_Fioo_q                    5.0000E+01    NORMALIZED  1.2917E-01
    FAIL ERS_Vnuopc_Ln9.f19_g16.X.cheyenne_intel  BASELINE restart_cime5.6.8
    FAIL SMS_Vnuopc.f19_g16.X.cheyenne_intel      BASELINE restart_cime5.6.8

    ---------------------------------------------------------------------
    The following restart test failse for
      RMS x2l_Flrr_flood                   2.0296E+14            NORMALIZED  2.0000E+00
      RMS x2l_Flrr_volr                    2.4355E+14            NORMALIZED  2.0000E+00
      RMS x2l_Flrr_volrmch                 2.8415E+14            NORMALIZED  2.0000E+00
    FAIL ERS_Vmct_Ln9.f19_g16.X.cheyenne_intel  COMPARE_base_rest

```

Fixes: None
User interface changes?: No
Update gh-pages html (Y/N)?: No
Code review: 
