### PR TITLE
Jedwards/update esmf and logging2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script: cd scripts/tests; ./scripts_regression_tests.py --machine centos7-linux 
 # it's pushed
 branches:
   only:
-  - master
+  - nuopc-cmeps

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -378,7 +378,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_IB_CONGESTED">1</env>
       <env name="MPI_USE_ARRAY"/>
       <!-- <env name="ESMFMKFILE">/glade/u/home/tcraig/ESMF-INSTALLS/ESMF_7_1_0_bs42-Intel17.0.1-NetCDF4.4.1.1-g/lib/esmf.mk</env> -->
-      <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/8.0.0bs08/lib/libO/Linux.intel.64.mpich2.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/8.0.0bs12/lib/libO/Linux.intel.64.mpich2.default/esmf.mk</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -377,8 +377,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="MPI_IB_CONGESTED">1</env>
       <env name="MPI_USE_ARRAY"/>
-      <!-- <env name="ESMFMKFILE">/glade/u/home/tcraig/ESMF-INSTALLS/ESMF_7_1_0_bs42-Intel17.0.1-NetCDF4.4.1.1-g/lib/esmf.mk</env> -->
-      <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/8.0.0bs12/lib/libO/Linux.intel.64.mpich2.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/8.0.0bs08/lib/libO/Linux.intel.64.mpich2.default/esmf.mk</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -47,8 +47,6 @@ from standard_script_setup import *
 import CIME.build as build
 from CIME.case            import Case
 from CIME.utils           import find_system_test
-from CIME.XML.files       import Files
-from CIME.XML.component   import Component
 from CIME.test_status     import *
 
 ###############################################################################

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -57,7 +57,7 @@ def parse_command_line(args, description):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    protocal, address, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
+    protocol, address, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
     with Case() as case:
         sys.exit(0 if case.check_all_input_data(protocol=protocol,
                                                 address=address,

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -135,7 +135,7 @@ def parse_command_line(args, cimeroot, description):
                         help="Use a non-default location for input files. This will change the xml value of DIN_LOC_ROOT.")
 
     # Select a driver. No selection implies mct driver
-    parser.add_argument("--driver", "-driver", default="mct", choices=('mct','nuopc'),
+    parser.add_argument("--driver", "-driver", default="nuopc", choices=('mct','nuopc'),
                         help=argparse.SUPPRESS)
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)

--- a/scripts/lib/CIME/XML/archive.py
+++ b/scripts/lib/CIME/XML/archive.py
@@ -34,7 +34,7 @@ class Archive(ArchiveBase):
 
         for comp in components:
             expect(driver != None, "must specify driver to acceptable value")
-            infile = files.get_value("ARCHIVE_SPEC_FILE", {"component":comp}, comp_interface=driver)
+            infile = files.get_value("ARCHIVE_SPEC_FILE", {"component":comp})
 
             if infile is not None and os.path.isfile(infile):
                 arch = Archive(infile=infile, files=files)

--- a/scripts/lib/CIME/XML/batch.py
+++ b/scripts/lib/CIME/XML/batch.py
@@ -93,10 +93,6 @@ class Batch(GenericXML):
         if node is not None:
             value = self.text(node)
 
-        if value is None:
-            # if all else fails
-            value = GenericXML.get_value(self, name, attribute, resolved, subgroup)
-
         if resolved:
             if value is not None:
                 value = self.get_resolved_value(value)

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -129,10 +129,6 @@ class Compilers(GenericXML):
         if node is not None:
             value = self.text(node)
 
-        if value is None:
-            # if all else fails
-            value = GenericXML.get_value(self, name)
-
         if resolved:
             if value is not None:
                 value = self.get_resolved_value(value)

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class Files(EntryID):
 
-    def __init__(self):
+    def __init__(self, comp_interface="nuopc"):
         """
         initialize an object
 
@@ -27,14 +27,14 @@ class Files(EntryID):
         config_files_override = os.path.join(os.path.dirname(cimeroot),".config_files.xml")
         # variables COMP_ROOT_DIR_{} are mutable, all other variables are read only
         self.COMP_ROOT_DIR = {}
-
+        self._comp_interface = comp_interface
         # .config_file.xml at the top level may overwrite COMP_ROOT_DIR_ nodes in config_files
 
         if os.path.isfile(config_files_override):
             self.read(config_files_override)
             self.overwrite_existing_entries()
 
-    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, comp_interface=None):
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
         if "COMP_ROOT_DIR" in vid:
             if vid in self.COMP_ROOT_DIR:
                 if attribute is not None:
@@ -56,9 +56,7 @@ class Files(EntryID):
                 value = value.replace("$"+comp_root_dir_var_name, comp_root_dir)
 
         if resolved and value is not None:
-            if "COMP_INTERFACE" in value:
-                expect(comp_interface != None, "comp_interface must have valid value for vid = {}".format(vid))
-                value = value.replace("$COMP_INTERFACE", comp_interface)
+            value = value.replace("$COMP_INTERFACE", self._comp_interface)
             value = self.get_resolved_value(value)
         return value
 

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -399,9 +399,6 @@ class GenericXML(object):
         valnodes = self.get_children(vid)
         for node in valnodes:
             self.set_text(node, value)
-        if node is not None:
-            return value
-        return None
 
     def get_resolved_value(self, raw_value, allow_unresolved_envvars=False):
         """
@@ -451,7 +448,11 @@ class GenericXML(object):
         for m in reference_re.finditer(item_data):
             var = m.groups()[0]
             logger.debug("find: {}".format(var))
-            if var == "CIMEROOT":
+            ref = self.get_value(var)
+            if ref is not None:
+                logger.debug("resolve: " + str(ref))
+                item_data = item_data.replace(m.group(), self.get_resolved_value(str(ref)))
+            elif var == "CIMEROOT":
                 cimeroot = get_cime_root()
                 item_data = item_data.replace(m.group(), cimeroot)
             elif var == "SRCROOT":

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -448,7 +448,7 @@ class GenericXML(object):
         for m in reference_re.finditer(item_data):
             var = m.groups()[0]
             logger.debug("find: {}".format(var))
-            ref = self.get_value(var)
+            ref = self.get_value(var) # pylint disable=assignment-from-none
             if ref is not None:
                 logger.debug("resolve: " + str(ref))
                 item_data = item_data.replace(m.group(), self.get_resolved_value(str(ref)))

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -399,6 +399,9 @@ class GenericXML(object):
         valnodes = self.get_children(vid)
         for node in valnodes:
             self.set_text(node, value)
+        if node is not None:
+            return value
+        return None
 
     def get_resolved_value(self, raw_value, allow_unresolved_envvars=False):
         """
@@ -448,11 +451,7 @@ class GenericXML(object):
         for m in reference_re.finditer(item_data):
             var = m.groups()[0]
             logger.debug("find: {}".format(var))
-            ref = self.get_value(var)
-            if ref is not None:
-                logger.debug("resolve: " + str(ref))
-                item_data = item_data.replace(m.group(), self.get_resolved_value(str(ref)))
-            elif var == "CIMEROOT":
+            if var == "CIMEROOT":
                 cimeroot = get_cime_root()
                 item_data = item_data.replace(m.group(), cimeroot)
             elif var == "SRCROOT":

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -399,6 +399,9 @@ class GenericXML(object):
         valnodes = self.get_children(vid)
         for node in valnodes:
             self.set_text(node, value)
+        if valnodes:
+            return value
+        return None
 
     def get_resolved_value(self, raw_value, allow_unresolved_envvars=False):
         """
@@ -448,7 +451,7 @@ class GenericXML(object):
         for m in reference_re.finditer(item_data):
             var = m.groups()[0]
             logger.debug("find: {}".format(var))
-            ref = self.get_value(var) # pylint disable=assignment-from-none
+            ref = self.get_value(var) # pylint: disable=assignment-from-none
             if ref is not None:
                 logger.debug("resolve: " + str(ref))
                 item_data = item_data.replace(m.group(), self.get_resolved_value(str(ref)))

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -191,10 +191,6 @@ class Machines(GenericXML):
             if node is not None:
                 value = self.text(node)
 
-        if value is None:
-            # if all else fails
-            value = GenericXML.get_value(self, name)
-
         if resolved:
             if value is not None:
                 value = self.get_resolved_value(value)
@@ -306,7 +302,7 @@ class Machines(GenericXML):
         tmproot = self.root
         self.root = self.machine_node
         result = super(Machines, self).set_value(vid, value, subgroup=subgroup,
-                                               ignore_type=ignore_type)
+                                               ignore_type=ignore_type) #pylint disable=assignment-from-no-return
         self.root = tmproot
         return result
 

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -302,7 +302,7 @@ class Machines(GenericXML):
         tmproot = self.root
         self.root = self.machine_node
         result = super(Machines, self).set_value(vid, value, subgroup=subgroup,
-                                               ignore_type=ignore_type) #pylint disable=assignment-from-no-return
+                                               ignore_type=ignore_type)
         self.root = tmproot
         return result
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -432,7 +432,7 @@ class Case(object):
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are {}".format(components))
 
         self.set_lookup_value("COMP_INTERFACE", driver)
-        comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", comp_interface=driver)
+        comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL")
         self.set_lookup_value("COMP_ROOT_DIR_CPL",comp_root_dir_cpl)
 
         # Loop through all of the files listed in COMPSETS_SPEC_FILE and find the file
@@ -440,7 +440,7 @@ class Case(object):
         for component in components:
 
             # Determine the compsets file for this component
-            compsets_filename = files.get_value("COMPSETS_SPEC_FILE", {"component":component}, comp_interface=driver)
+            compsets_filename = files.get_value("COMPSETS_SPEC_FILE", {"component":component})
 
             # If the file exists, read it and see if there is a match for the compset alias or longname
             if (os.path.isfile(compsets_filename)):
@@ -518,7 +518,7 @@ class Case(object):
         return primary_component
 
 
-    def _set_info_from_primary_component(self, files, pesfile=None, driver=None):
+    def _set_info_from_primary_component(self, files, pesfile=None):
         """
         Sets file and directory paths that depend on the primary component of
         this compset.
@@ -532,7 +532,7 @@ class Case(object):
 
         self.set_lookup_value("COMPSETS_SPEC_FILE" ,compset_spec_file)
         if pesfile is None:
-            self._pesfile = files.get_value("PES_SPEC_FILE", {"component":component}, comp_interface=driver)
+            self._pesfile = files.get_value("PES_SPEC_FILE", {"component":component})
             pesfile_unresolved = files.get_value("PES_SPEC_FILE", {"component":component}, resolved=False)
             logger.info("Pes     specification file is {}".format(self._pesfile))
         else:
@@ -597,13 +597,12 @@ class Case(object):
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(files, attlist)
 
-        comp_interface = self.lookups["COMP_INTERFACE"]
-        drv_config_file = files.get_value("CONFIG_CPL_FILE", {"component":comp_interface}, comp_interface=driver)
+        drv_config_file = files.get_value("CONFIG_CPL_FILE")
         drv_comp = Component(drv_config_file, "CPL")
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(drv_comp, attributes=attlist)
 
-        drv_config_file_model_specific = files.get_value("CONFIG_CPL_FILE_MODEL_SPECIFIC", comp_interface=driver)
+        drv_config_file_model_specific = files.get_value("CONFIG_CPL_FILE_MODEL_SPECIFIC")
         drv_comp_model_specific = Component(drv_config_file_model_specific, 'CPL')
 
         self._component_description["forcing"] = drv_comp_model_specific.get_forcing_description(self._compsetname)
@@ -625,7 +624,7 @@ class Case(object):
 
         # will need a change here for new cpl components
         root_dir_node_name = 'COMP_ROOT_DIR_CPL'
-        comp_root_dir = files.get_value(root_dir_node_name, {"component":comp_interface}, resolved=False)
+        comp_root_dir = files.get_value(root_dir_node_name, {"component":driver}, resolved=False)
 
         if comp_root_dir is not None:
             self.set_value(root_dir_node_name, comp_root_dir)
@@ -644,7 +643,7 @@ class Case(object):
             comp_config_file = files.get_value(node_name, compatt, resolved=False)
             expect(comp_config_file is not None,"No component {} found for class {}".format(comp_name, comp_class))
             self.set_value(node_name, comp_config_file)
-            comp_config_file =  files.get_value(node_name, compatt, comp_interface=driver)
+            comp_config_file =  files.get_value(node_name, compatt)
             expect(comp_config_file is not None and os.path.isfile(comp_config_file),
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
             compobj = Component(comp_config_file, comp_class)
@@ -773,7 +772,7 @@ class Case(object):
         #--------------------------------------------
         # compset, pesfile, and compset components
         #--------------------------------------------
-        files = Files()
+        files = Files(comp_interface=driver)
 
         compset_alias, science_support = self._set_compset(compset_name, files, driver)
 
@@ -801,7 +800,7 @@ class Case(object):
         # from self._get_component_config_data
         self._primary_component = self.get_primary_component()
 
-        self._set_info_from_primary_component(files, pesfile=pesfile, driver=driver)
+        self._set_info_from_primary_component(files, pesfile=pesfile)
 
         self.clean_up_lookups(allow_undefined=True)
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1397,7 +1397,7 @@ directory, NOT in this subdirectory."""
         self._files.remove(old_object)
         self._files.append(new_object)
 
-    def get_latest_cpl_log(self, coupler_log_path=None):
+    def get_latest_cpl_log(self, coupler_log_path=None, cplname="med"):
         """
         find and return the latest cpl log file in the
         coupler_log_path directory
@@ -1405,7 +1405,7 @@ directory, NOT in this subdirectory."""
         if coupler_log_path is None:
             coupler_log_path = self.get_value("RUNDIR")
         cpllog = None
-        cpllogs = glob.glob(os.path.join(coupler_log_path, 'cpl.log.*'))
+        cpllogs = glob.glob(os.path.join(coupler_log_path, '{}.log.*'.format(cplname)))
         if cpllogs:
             cpllog = max(cpllogs, key=os.path.getctime)
             return cpllog

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -435,11 +435,15 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
 
     # copy latest cpl log to baseline
     # drop the date so that the name is generic
-    newestcpllogfile = case.get_latest_cpl_log(coupler_log_path=case.get_value("RUNDIR"))
-    if newestcpllogfile is None:
-        logger.warning("No cpl.log file found in directory {}".format(case.get_value("RUNDIR")))
+    if case.get_value("COMP_INTERFACE") == "nuopc":
+        cplname = "med"
     else:
-        safe_copy(newestcpllogfile, os.path.join(basegen_dir, "cpl.log.gz"))
+        cplname = "cpl"
+    newestcpllogfile = case.get_latest_cpl_log(coupler_log_path=case.get_value("RUNDIR"), cplname=cplname)
+    if newestcpllogfile is None:
+        logger.warning("No {}.log file found in directory {}".format(cplname,case.get_value("RUNDIR")))
+    else:
+        safe_copy(newestcpllogfile, os.path.join(basegen_dir, "{}.log.gz".format(cplname)))
 
     expect(num_gen > 0, "Could not generate any hist files for case '{}', something is seriously wrong".format(os.path.join(rundir, testcase)))
     #make sure permissions are open in baseline directory

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -17,7 +17,7 @@ def _iter_model_file_substrs(case):
     for model in models:
         yield model
 
-def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=None):
+def _get_all_hist_files(model, from_dir, suffix="", file_extensions=None):
     suffix = (".{}".format(suffix) if suffix else "")
 
     test_hists = []
@@ -35,8 +35,8 @@ def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=No
     logger.debug("_get_all_hist_files returns {} for model {}".format(test_hists, model))
     return test_hists
 
-def _get_latest_hist_files(testcase, model, from_dir, suffix="", file_extensions=None):
-    test_hists = _get_all_hist_files(testcase, model, from_dir, suffix, file_extensions)
+def _get_latest_hist_files(model, from_dir, suffix="", file_extensions=None):
+    test_hists = _get_all_hist_files(model, from_dir, suffix, file_extensions)
     latest_files = {}
     histlist = []
     for hist in test_hists:
@@ -57,7 +57,6 @@ def copy(case, suffix):
     suffix - The string suffix you want to add to saved files, this can be used to find them later.
     """
     rundir   = case.get_value("RUNDIR")
-    testcase = case.get_value("CASE")
 
     # Loop over models
     archive = case.get_env("archive")
@@ -69,7 +68,7 @@ def copy(case, suffix):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        test_hists = _get_latest_hist_files(testcase, model, rundir, file_extensions=file_extensions)
+        test_hists = _get_latest_hist_files(model, rundir, file_extensions=file_extensions)
         num_copied += len(test_hists)
         for test_hist in test_hists:
             new_file = "{}.{}".format(test_hist, suffix)
@@ -196,8 +195,8 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        hists1 = _get_latest_hist_files(testcase, model, from_dir1, suffix1, file_extensions)
-        hists2 = _get_latest_hist_files(testcase, model, from_dir2, suffix2, file_extensions)
+        hists1 = _get_latest_hist_files(model, from_dir1, suffix1, file_extensions)
+        hists2 = _get_latest_hist_files(model, from_dir2, suffix2, file_extensions)
         if len(hists1) == 0 and len(hists2) == 0:
             comments += "    no hist files found for model {}\n".format(model)
             continue
@@ -422,7 +421,7 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        hists =  _get_latest_hist_files(testcase, model, rundir, file_extensions=file_extensions)
+        hists =  _get_latest_hist_files(model, rundir, file_extensions=file_extensions)
         logger.debug("latest_files: {}".format(hists))
         num_gen += len(hists)
         for hist in hists:

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1060,9 +1060,9 @@ class Namelist(object):
         """
         gn = string_in_list(group_name,self._groups)
         if gn:
-           vn=string_in_list(variable_name,self._groups[gn])
-           if vn:
-               del self._groups[gn][vn]
+            vn=string_in_list(variable_name,self._groups[gn])
+            if vn:
+                del self._groups[gn][vn]
 
     def merge_nl(self, other, overwrite=False):
         """Merge this namelist object with another.
@@ -1134,7 +1134,7 @@ class Namelist(object):
         return group_variables
 
     def write(self, out_file, groups=None, append=False, format_='nml', sorted_groups=True,
-              skip_comps=None, prognostic_comps=None, atm_cpl_dt=None, ocn_cpl_dt=None):
+              skip_comps=None, atm_cpl_dt=None, ocn_cpl_dt=None):
         """Write a the output data (normally fortran namelist) to the  out_file
 
         As with `parse`, the `out_file` argument can be either a file name, or a
@@ -1163,7 +1163,7 @@ class Namelist(object):
         else:
             logger.debug("Writing namelist to file object")
             if format_ == 'nuopc':
-                self._write_noupc(out_file, groups, sorted_groups=sorted_groups,
+                self._write_nuopc(out_file, groups, sorted_groups=sorted_groups,
                                   skip_comps=skip_comps, atm_cpl_dt=atm_cpl_dt, ocn_cpl_dt=ocn_cpl_dt)
             else:
                 self._write(out_file, groups, format_, sorted_groups=sorted_groups)
@@ -1240,7 +1240,6 @@ class Namelist(object):
                     for skip_comp in skip_comps:
                         if skip_comp in values[0]:
                             values[0] = values[0].replace(skip_comp,"")
-                components = values[0]
 
                 # @ is used in a namelist to put the same namelist variable in multiple groups
                 # in the write phase, all characters in the namelist variable name after

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -107,7 +107,7 @@ import collections
 # pylint: disable=wildcard-import,unused-wildcard-import
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect
+from CIME.utils import expect, string_in_list
 import six
 
 logger = logging.getLogger(__name__)
@@ -898,10 +898,9 @@ class Namelist(object):
         if groups is not None:
             for group_name in groups:
                 expect(group_name is not None, " Got None in groups {}".format(groups))
-                group_lc = group_name.lower()
-                self._groups[group_lc] = collections.OrderedDict()
+                self._groups[group_name] = collections.OrderedDict()
                 for variable_name in groups[group_name]:
-                    self._groups[group_lc][variable_name.lower()] = groups[group_name][variable_name]
+                    self._groups[group_name][variable_name] = groups[group_name][variable_name]
 
     def clean_groups(self):
         self._groups = collections.OrderedDict()
@@ -933,10 +932,10 @@ class Namelist(object):
         >>> sorted(x.get_variable_names('fOo'))
         ['bar(::)', 'bazz', 'bazz(2)', 'bazz(:2:)']
         """
-        group_name = group_name.lower()
-        if group_name not in self._groups:
+        gn = string_in_list(group_name,self._groups)
+        if not gn:
             return []
-        return list(self._groups[group_name].keys())
+        return list(self._groups[gn].keys())
 
     def get_variable_value(self, group_name, variable_name):
         """Return the value of the specified variable.
@@ -952,13 +951,12 @@ class Namelist(object):
         >>> parse(text='&foo bar=1,2 /').get_variable_value('foO', 'Bar')
         ['1', '2']
         """
-        group_name = group_name.lower()
-        variable_name = variable_name.lower()
-        if group_name not in self._groups or \
-           variable_name not in self._groups[group_name]:
-            return ['']
-
-        return self._groups[group_name][variable_name]
+        gn = string_in_list(group_name,self._groups)
+        if gn:
+            vn = string_in_list(variable_name,self._groups[gn])
+            if vn:
+                return self._groups[gn][vn]
+        return ['']
 
     def get_value(self, variable_name):
         """Return the value of a uniquely-named variable.
@@ -978,14 +976,18 @@ class Namelist(object):
         >>> parse(text='&foo / &bazz /').get_value('bar')
         ['']
         """
-        variable_name = variable_name.lower()
-        possible_groups = [group_name for group_name in self._groups
-                           if variable_name in self._groups[group_name]]
+        possible_groups = []
+        vn = None
+        for group_name in self._groups:
+            vnt = string_in_list(variable_name, self._groups[group_name])
+            if vnt:
+                vn = vnt
+                possible_groups.append(group_name)
         expect(len(possible_groups) <= 1,
                "Namelist.get_value: Variable {} is present in multiple groups: "
                + str(possible_groups))
         if possible_groups:
-            return self._groups[possible_groups[0]][variable_name]
+            return self._groups[possible_groups[0]][vn]
         else:
             return ['']
 
@@ -1015,29 +1017,32 @@ class Namelist(object):
         ['', '2', '', '4', '', '6']
         """
         minindex, maxindex, step = get_fortran_variable_indices(variable_name, var_size)
-        variable_name = get_fortran_name_only(variable_name.lower())
+        variable_name = get_fortran_name_only(variable_name)
 
         expect(minindex > 0, "Indices < 1 not supported in CIME interface to fortran namelists... lower bound={}".format(minindex))
-        group_name = group_name.lower()
-        if group_name not in self._groups:
-            self._groups[group_name] = {}
+        gn = string_in_list(group_name,self._groups)
+        if not gn:
+            gn = group_name
+            self._groups[gn] = {}
+
         tlen = 1
-        if variable_name in self._groups[group_name]:
-            tlen = len(self._groups[group_name][variable_name])
+        vn = string_in_list(variable_name, self._groups[gn])
+        if vn:
+            tlen = len(self._groups[gn][vn])
         else:
+            vn = variable_name
             tlen = 1
-            self._groups[group_name][variable_name] = ['']
+            self._groups[gn][vn] = ['']
 
         if minindex > tlen:
-            self._groups[group_name][variable_name].extend(['']*(minindex-tlen-1))
+            self._groups[gn][vn].extend(['']*(minindex-tlen-1))
 
         for i in range(minindex, maxindex+2*step, step):
-            while len(self._groups[group_name][variable_name]) < i:
-                self._groups[group_name][variable_name].append('')
-            self._groups[group_name][variable_name][i-1] = value.pop(0)
+            while len(self._groups[gn][vn]) < i:
+                self._groups[gn][vn].append('')
+            self._groups[gn][vn][i-1] = value.pop(0)
             if len(value) == 0:
                 break
-
 
     def delete_variable(self, group_name, variable_name):
         """Delete a variable from a specified group.
@@ -1053,11 +1058,11 @@ class Namelist(object):
         >>> x.get_variable_names('brack')
         []
         """
-        group_name = group_name.lower()
-        variable_name = variable_name.lower()
-        if group_name in self._groups and \
-           variable_name in self._groups[group_name]:
-            del self._groups[group_name][variable_name]
+        gn = string_in_list(group_name,self._groups)
+        if gn:
+           vn=string_in_list(variable_name,self._groups[gn])
+           if vn:
+               del self._groups[gn][vn]
 
     def merge_nl(self, other, overwrite=False):
         """Merge this namelist object with another.
@@ -1129,7 +1134,7 @@ class Namelist(object):
         return group_variables
 
     def write(self, out_file, groups=None, append=False, format_='nml', sorted_groups=True,
-              skip_comps=None, atm_cpl_dt=None, ocn_cpl_dt=None):
+              skip_comps=None, prognostic_comps=None, atm_cpl_dt=None, ocn_cpl_dt=None):
         """Write a the output data (normally fortran namelist) to the  out_file
 
         As with `parse`, the `out_file` argument can be either a file name, or a
@@ -1158,7 +1163,7 @@ class Namelist(object):
         else:
             logger.debug("Writing namelist to file object")
             if format_ == 'nuopc':
-                self._write_nuopc(out_file, groups, sorted_groups=sorted_groups,
+                self._write_noupc(out_file, groups, sorted_groups=sorted_groups,
                                   skip_comps=skip_comps, atm_cpl_dt=atm_cpl_dt, ocn_cpl_dt=ocn_cpl_dt)
             else:
                 self._write(out_file, groups, format_, sorted_groups=sorted_groups)
@@ -1172,7 +1177,7 @@ class Namelist(object):
         elif format_ == 'rc':
             equals = ':'
         if (sorted_groups):
-            group_names = sorted(group.lower() for group in groups)
+            group_names = sorted(group for group in groups)
         else:
             group_names = groups
         for group_name in group_names:
@@ -1217,7 +1222,6 @@ class Namelist(object):
             groups = self._groups.keys()
 
         if (sorted_groups):
-            #group_names = sorted(group.lower() for group in groups)
             group_names = sorted(group for group in groups)
         else:
             group_names = groups
@@ -1236,6 +1240,7 @@ class Namelist(object):
                     for skip_comp in skip_comps:
                         if skip_comp in values[0]:
                             values[0] = values[0].replace(skip_comp,"")
+                components = values[0]
 
                 # @ is used in a namelist to put the same namelist variable in multiple groups
                 # in the write phase, all characters in the namelist variable name after

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -123,7 +123,7 @@ class TestScheduler(object):
     ###########################################################################
         self._cime_root       = CIME.utils.get_cime_root()
         self._cime_model      = get_model()
-        self._cime_driver     = "mct"
+        self._cime_driver     = "nuopc"
         self._save_timing     = save_timing
         self._queue           = queue
         self._test_data       = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
@@ -419,9 +419,6 @@ class TestScheduler(object):
             create_newcase_cmd += " --machine {}".format(machine)
         if compiler is not None:
             create_newcase_cmd += " --compiler {}".format(compiler)
-        if "Vnuopc" in case_opts:
-            create_newcase_cmd += " --driver nuopc "
-            self._cime_driver = "nuopc"
         if self._project is not None:
             create_newcase_cmd += " --project {} ".format(self._project)
         if self._output_root is not None:
@@ -433,7 +430,7 @@ class TestScheduler(object):
             create_newcase_cmd += " --pesfile {} ".format(self._pesfile)
 
         if test_mods is not None:
-            files = Files()
+            files = Files(comp_interface=self._cime_driver)
             if test_mods.find('/') != -1:
                 (component, modspath) = test_mods.split('/', 1)
             else:
@@ -446,7 +443,7 @@ class TestScheduler(object):
             comp_root_dir_cpl = files.get_value( "COMP_ROOT_DIR_CPL",{"component":"drv-nuopc"}, resolved=False)
             files.set_value("COMP_ROOT_DIR_CPL", comp_root_dir_cpl)
 
-            testmods_dir = files.get_value("TESTS_MODS_DIR", {"component": component}, comp_interface=self._cime_driver)
+            testmods_dir = files.get_value("TESTS_MODS_DIR", {"component": component})
             test_mod_file = os.path.join(testmods_dir, component, modspath)
             if not os.path.exists(test_mod_file):
                 error = "Missing testmod file '{}'".format(test_mod_file)
@@ -478,8 +475,9 @@ class TestScheduler(object):
                     pesize = case_opt[1:]
                     create_newcase_cmd += " --pecount {}".format(pesize)
                 elif case_opt.startswith('V'):
-                    driver = case_opt[1:]
-                    create_newcase_cmd += " --driver {}".format(driver)
+                    self._cime_driver = case_opt[1:]
+                    create_newcase_cmd += " --driver {}".format(self._cime_driver)
+
 
         # create_test mpilib option overrides default but not explicitly set case_opt mpilib
         if mpilib is None and self._mpilib is not None:
@@ -526,8 +524,8 @@ class TestScheduler(object):
 
         # Determine list of component classes that this coupler/driver knows how
         # to deal with. This list follows the same order as compset longnames follow.
-        files = Files()
-        drv_config_file = files.get_value("CONFIG_CPL_FILE", comp_interface=self._cime_driver)
+        files = Files(comp_interface=self._cime_driver)
+        drv_config_file = files.get_value("CONFIG_CPL_FILE")
         drv_comp = Component(drv_config_file, "CPL")
         envtest.add_elements_by_group(files, {}, "env_test.xml")
         envtest.add_elements_by_group(drv_comp, {}, "env_test.xml")

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1727,3 +1727,17 @@ def run_bld_cmd_ensure_logging(cmd, arg_logger, from_dir=None):
 
 def get_batch_script_for_job(job):
     return job if "st_archive" in job else "." + job
+
+def string_in_list(string, _list):
+    """Case insensitive search for string in list
+    returns the matching list value
+    >>> string_in_list("Brack",["bar", "bracK", "foo"])
+    'bracK'
+    >>> string_in_list("foo", ["FFO", "FOO", "foo2", "foo3"])
+    'FOO'
+    >>> string_in_list("foo", ["FFO", "foo2", "foo3"])
+    """
+    for x in _list:
+        if string.lower() == x.lower():
+            return x
+    return None

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1728,7 +1728,7 @@ def run_bld_cmd_ensure_logging(cmd, arg_logger, from_dir=None):
 def get_batch_script_for_job(job):
     return job if "st_archive" in job else "." + job
 
-def string_in_list(string, _list):
+def string_in_list(_string, _list):
     """Case insensitive search for string in list
     returns the matching list value
     >>> string_in_list("Brack",["bar", "bracK", "foo"])
@@ -1738,6 +1738,6 @@ def string_in_list(string, _list):
     >>> string_in_list("foo", ["FFO", "foo2", "foo3"])
     """
     for x in _list:
-        if string.lower() == x.lower():
+        if _string.lower() == x.lower():
             return x
     return None

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -23,8 +23,8 @@ def query_grids(long_output):
     """
     query all grids.
     """
-    files = Files()
-    config_file = files.get_value("GRIDS_SPEC_FILE", comp_interface="mct")
+    files = Files(comp_interface="nuopc")
+    config_file = files.get_value("GRIDS_SPEC_FILE")
     expect(os.path.isfile(config_file),
            "Cannot find config_file {} on disk".format(config_file))
 
@@ -38,8 +38,8 @@ def query_machines(machine_name='all'):
     """
     query machines. Defaule: all
     """
-    files = Files()
-    config_file = files.get_value("MACHINES_SPEC_FILE", comp_interface="mct")
+    files = Files(comp_interface="nuopc")
+    config_file = files.get_value("MACHINES_SPEC_FILE")
     expect(os.path.isfile(config_file),
            "Cannot find config_file {} on disk".format(config_file))
     # Provide a special machine name indicating no need for a machine name
@@ -81,7 +81,7 @@ def print_compset(name, files, all_components=False):
     """
 
     # Determine the config_file for the target component
-    config_file = files.get_value("COMPSETS_SPEC_FILE", attribute={"component":name}, comp_interface="mct")
+    config_file = files.get_value("COMPSETS_SPEC_FILE", attribute={"component":name})
     # only error out if we aren't printing all otherwise exit quitely
     if not all_components:
         expect((config_file),
@@ -140,9 +140,9 @@ def query_component(name, all_components=False):
         logger.debug ("{}: valid_components {}".format(comp, valid_components))
         # determine if config_file is on disk
         if name is None:
-            config_file = files.get_value(string, comp_interface="mct")
+            config_file = files.get_value(string)
         elif name in valid_components:
-            config_file = files.get_value(string, attribute={"component":name}, comp_interface="mct")
+            config_file = files.get_value(string, attribute={"component":name})
             logger.debug("query {}".format(config_file))
         if config_file is not None:
             match_found = True
@@ -210,7 +210,7 @@ def parse_command_line(args, description):
     parser.add_argument("--grids", action="store_true",
                         help="Query supported model grids for {} model.".format(cime_model))
 
-    config_file = files.get_value("MACHINES_SPEC_FILE", comp_interface="mct")
+    config_file = files.get_value("MACHINES_SPEC_FILE")
     expect(os.path.isfile(config_file),
            "Cannot find config_file {} on disk".format(config_file))
     machines = Machines(config_file, machine="Query")
@@ -246,7 +246,7 @@ def get_components():
     These are then stored in comps_array
     """
     files = Files()
-    infile = files.get_value("CONFIG_CPL_FILE", comp_interface="mct")
+    infile = files.get_value("CONFIG_CPL_FILE")
     config_drv = Component(infile, "CPL")
     return files, config_drv.get_valid_model_components()
 
@@ -295,7 +295,7 @@ class Machines(CIME.XML.machines.Machines):
         # if we can't find the specified machine
         if single_machine and machine_name is None:
             files = Files()
-            config_file = files.get_value("MACHINES_SPEC_FILE", comp_interface="mct")
+            config_file = files.get_value("MACHINES_SPEC_FILE")
             print("Machine is not listed in config file: {}".format(config_file))
         else:  # write out machines
             if single_machine:

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2709,7 +2709,7 @@ def make_pylint_test(pyfile, all_files):
     def test(self):
         if B_CheckCode.all_results is None:
             B_CheckCode.all_results = check_code(all_files)
-        result = B_CheckCode.all_results[pyfile]
+        result = B_CheckCode.all_results[pyfile]  # pylint: disable=unsubscriptable-object
         self.assertTrue(result == "", msg=result)
 
     return test

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from standard_script_setup import *
-from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging
+from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging, expect
 from CIME.case import Case
 import glob
 
@@ -62,7 +62,7 @@ def buildlib(bldroot, installpath, caseroot):
             filepath.append(os.path.join(cimeroot,"src","drivers","nuopc","shr"))
             filepath.append(os.path.join(cimeroot,"src","drivers","nuopc","cime_flds"))
         else:
-            expect(False, "driver value of {} not supported".format(driver)) 
+            expect(False, "driver value of {} not supported".format(driver))
 
         if case.get_value("USE_ESMF_LIB"):
             use_esmf = "esmf"

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -113,7 +113,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         atmdt = int(basedt / case.get_value('ATM_NCPL'))
         expect(atmdt == mindt, 'Active atm should match shortest model timestep atmdt={} mindt={}'
                .format(atmdt, mindt))
-            
+
 
     #--------------------------------
     # Overwrite: set start_ymd
@@ -272,7 +272,7 @@ def write_drv_flds_in_file(case, nmlgen, files):
 
         # Now create drv_flds_in
         config = {}
-        definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}, comp_interface="mct"))
+        definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}))
         definition_file = [os.path.join(definition_dir, "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file, files=files)
         skip_entry_loop = True
@@ -362,8 +362,8 @@ def buildnml(case, caseroot, component):
     expect (os.path.isdir(user_xml_dir),
             "user_xml_dir {} does not exist ".format(user_xml_dir))
 
-    files = Files()
-    definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", {"component": "drv"}, comp_interface="mct")]
+    files = Files(comp_interface="mct")
+    definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", {"component": "drv"})]
 
     user_definition = os.path.join(user_xml_dir, "namelist_definition_drv.xml")
     if os.path.isfile(user_definition):

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -295,7 +295,7 @@ def _create_component_modelio_namelists(case, files):
 
     # will need to create a new namelist generator
     infiles = []
-    definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}, comp_interface="mct"))
+    definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}))
     definition_file = [os.path.join(definition_dir, "namelist_definition_modelio.xml")]
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")

--- a/src/drivers/nuopc/cime_config/buildnml
+++ b/src/drivers/nuopc/cime_config/buildnml
@@ -269,7 +269,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 
         # Now create drv_flds_in
         config = {}
-        definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"},comp_interface="nuopc"))
+        definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}))
         definition_file = [os.path.join(definition_dir, "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file, files=files)
         skip_entry_loop = True
@@ -293,7 +293,7 @@ def _create_component_modelio_namelists(confdir, case, files):
 
     # will need to create a new namelist generator
     infiles = []
-    definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"},comp_interface="nuopc"))
+    definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}))
     definition_file = [os.path.join(definition_dir, "namelist_definition_modelio.xml")]
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")

--- a/src/drivers/nuopc/cime_config/buildnml
+++ b/src/drivers/nuopc/cime_config/buildnml
@@ -203,9 +203,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
 
     comp_types = ['atm','lnd','ice','ocn','rof','glc','wav','esp']
-    stub_types = [ 's' + x for x in comp_types]
-    xcpl_types = [ 'x' + x for x in comp_types]
-    data_types = [ 'd' + x for x in comp_types]
 
     # Determine components that are not present
     skip_comps = []
@@ -372,14 +369,14 @@ def buildnml(case, caseroot, component):
     expect (os.path.isdir(user_xml_dir),
             "user_xml_dir %s does not exist " %user_xml_dir)
 
-    files = Files()
+    files = Files(comp_interface="nuopc")
 
     # TODO: to get the right attributes of COMP_ROOT_DIR_CPL in evaluating definition_file - need
     # to do the following first - this needs to be changed so that the following two lines are not needed!
     comp_root_dir_cpl = files.get_value( "COMP_ROOT_DIR_CPL",{"component":"drv-nuopc"}, resolved=False)
     files.set_value("COMP_ROOT_DIR_CPL", comp_root_dir_cpl)
 
-    definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", {"component": "drv-nuopc"}, comp_interface="nuopc")]
+    definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", {"component": "drv-nuopc"})]
     user_definition = os.path.join(user_xml_dir, "namelist_definition_drv.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]

--- a/src/drivers/nuopc/cime_driver/esmApp.F90
+++ b/src/drivers/nuopc/cime_driver/esmApp.F90
@@ -9,6 +9,7 @@ program esmApp
   use ESMF, only : ESMF_GridCompSetServices, ESMF_GridCompFinalize, ESMF_LogSet, ESMF_LogWrite
   use ESMF, only : ESMF_GridCompDestroy, ESMF_LOGMSG_INFO, ESMF_GridComp, ESMF_GridCompRun
   use ESMF, only : ESMF_GridCompFinalize, ESMF_GridCompCreate, ESMF_GridCompInitialize
+  use ESMF, only : ESMF_LOGKIND_MULTI_ON_ERROR
   use ESM,  only: esmSS => SetServices
 
   implicit none

--- a/src/drivers/nuopc/cime_driver/esmApp.F90
+++ b/src/drivers/nuopc/cime_driver/esmApp.F90
@@ -17,10 +17,13 @@ program esmApp
   type(ESMF_GridComp)     :: esmComp
 
   ! Initialize ESMF
+#ifdef DEBUG
   call ESMF_Initialize(logkindflag=ESMF_LOGKIND_MULTI, logappendflag=.false., &
     defaultCalkind=ESMF_CALKIND_GREGORIAN, ioUnitLBound=5001, ioUnitUBound=5101, rc=rc)
-  ! call ESMF_Initialize(logkindflag=ESMF_LOGKIND_MULTI_ON_ERROR, logappendflag=.false., &
-  !   defaultCalkind=ESMF_CALKIND_GREGORIAN, ioUnitLBound=5001, ioUnitUBound=5101, rc=rc)
+#else
+  call ESMF_Initialize(logkindflag=ESMF_LOGKIND_MULTI_ON_ERROR, logappendflag=.false., &
+    defaultCalkind=ESMF_CALKIND_GREGORIAN, ioUnitLBound=5001, ioUnitUBound=5101, rc=rc)
+#endif
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, &
     file=__FILE__)) &

--- a/src/drivers/nuopc/cime_driver/esmApp.F90
+++ b/src/drivers/nuopc/cime_driver/esmApp.F90
@@ -9,7 +9,7 @@ program esmApp
   use ESMF, only : ESMF_GridCompSetServices, ESMF_GridCompFinalize, ESMF_LogSet, ESMF_LogWrite
   use ESMF, only : ESMF_GridCompDestroy, ESMF_LOGMSG_INFO, ESMF_GridComp, ESMF_GridCompRun
   use ESMF, only : ESMF_GridCompFinalize, ESMF_GridCompCreate, ESMF_GridCompInitialize
-  use ESMF, only : ESMF_LOGKIND_MULTI_ON_ERROR
+!  use ESMF, only : ESMF_LOGKIND_MULTI_ON_ERROR
   use ESM,  only: esmSS => SetServices
 
   implicit none
@@ -18,13 +18,13 @@ program esmApp
   type(ESMF_GridComp)     :: esmComp
 
   ! Initialize ESMF
-#ifdef DEBUG
+!#ifdef DEBUG
   call ESMF_Initialize(logkindflag=ESMF_LOGKIND_MULTI, logappendflag=.false., &
     defaultCalkind=ESMF_CALKIND_GREGORIAN, ioUnitLBound=5001, ioUnitUBound=5101, rc=rc)
-#else
-  call ESMF_Initialize(logkindflag=ESMF_LOGKIND_MULTI_ON_ERROR, logappendflag=.false., &
-    defaultCalkind=ESMF_CALKIND_GREGORIAN, ioUnitLBound=5001, ioUnitUBound=5101, rc=rc)
-#endif
+!#else
+!  call ESMF_Initialize(logkindflag=ESMF_LOGKIND_MULTI_ON_ERROR, logappendflag=.false., &
+!    defaultCalkind=ESMF_CALKIND_GREGORIAN, ioUnitLBound=5001, ioUnitUBound=5101, rc=rc)
+!#endif
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, &
     file=__FILE__)) &

--- a/src/drivers/nuopc/cime_flds/esmFlds.F90
+++ b/src/drivers/nuopc/cime_flds/esmFlds.F90
@@ -1482,15 +1482,6 @@ contains
     call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compice,  mapfcopy, 'unset', 'unset')
     call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compwav,  mapbilnr, 'one'  , 'ocn2wav_smapname')
 
-    longname = 'Fraction of sw penetrating surface layer for diurnal cycle'
-    stdname  = 'Fraction_of_sw_penetrating_surface_layer'
-    units    = '1'
-    call shr_nuopc_fldList_AddMetadata(fldname="So_fswpen", longname=longname, stdname=stdname, units=units)
-    call shr_nuopc_fldList_AddFld(fldListFr(compocn)%flds , 'So_fswpen', fldindex=n1)
-    call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'So_fswpen')
-    call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'So_fswpen')
-    call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compice,  mapfcopy, 'unset', 'unset')
-
     longname = 'Meridional sea water velocity'
     stdname  = 'northward_sea_water_velocity'
     units    = 'm s-1'

--- a/src/drivers/nuopc/cime_flds/esmFlds.F90
+++ b/src/drivers/nuopc/cime_flds/esmFlds.F90
@@ -1482,6 +1482,15 @@ contains
     call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compice,  mapfcopy, 'unset', 'unset')
     call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compwav,  mapbilnr, 'one'  , 'ocn2wav_smapname')
 
+    longname = 'Fraction of sw penetrating surface layer for diurnal cycle'
+    stdname  = 'Fraction_of_sw_penetrating_surface_layer'
+    units    = '1'
+    call shr_nuopc_fldList_AddMetadata(fldname="So_fswpen", longname=longname, stdname=stdname, units=units)
+    call shr_nuopc_fldList_AddFld(fldListFr(compocn)%flds , 'So_fswpen', fldindex=n1)
+    call shr_nuopc_fldList_AddFld(fldListMed_aoflux_a%flds, 'So_fswpen')
+    call shr_nuopc_fldList_AddFld(fldListMed_aoflux_o%flds, 'So_fswpen')
+    call shr_nuopc_fldList_AddMap(fldListFr(compocn)%flds(n1), compocn, compice,  mapfcopy, 'unset', 'unset')
+
     longname = 'Meridional sea water velocity'
     stdname  = 'northward_sea_water_velocity'
     units    = 'm s-1'

--- a/src/drivers/nuopc/mediator/med_phases_aofluxes_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_aofluxes_mod.F90
@@ -666,7 +666,7 @@ contains
          aoflux%roce_16O, aoflux%roce_HDO, aoflux%roce_18O, &
          aoflux%evap, aoflux%evap_16O, aoflux%evap_HDO, aoflux%evap_18O, &
          aoflux%taux, aoflux%tauy, aoflux%tref, aoflux%qref, &
-         aoflux%duu10n, aoflux%ustar, aoflux%re, aoflux%ssq)
+         aoflux%duu10n, ustar_sv=aoflux%ustar, re_sv=aoflux%re, ssq_sv=aoflux%ssq)
 
     do n = 1,lsize
        if (aoflux%mask(n) /= 0) then


### PR DESCRIPTION
Refactor namelist.py to be case-insensitive in the sense that it will accept input in any case but it
will produce output files using the case as defined in namelist_definition.xml.   This allows both fortran namelists (case insensitive) and esmf config files (case sensitive) to be parsed in the same way.    Fix issues with pylint and unit tests in python.    

Test suite: scripts_regression_tests.py A_RunUnitTests B_CheckCode, testlist_cmeps.xml
Test baseline: restart_cime5.6.8
Test namelist changes: namelist items are reordered 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: dunlap
