### PR TITLE
Get DTEST NUOPC restart capability working

### DIFF
--- a/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
@@ -641,7 +641,6 @@ module atm_comp_nuopc
     call shr_nuopc_grid_ArrayToState(d2x%rattr, flds_a2x, exportState, grid_option, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !TODO: do we still need the nx and ny scalars?
     call shr_nuopc_methods_State_SetScalar(dble(nx_global),flds_scalar_index_nx, exportState, mpicom, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -50,7 +50,7 @@ module docn_comp_mod
   logical       :: firstcall = .true.    ! first call logical
 
   character(len=*),parameter :: rpfile = 'rpointer.ocn'
-  integer(IN)   :: dbug = 1              ! debug level (higher is more)
+  integer(IN)   :: dbug = 0              ! debug level (higher is more)
 
   real(R8),parameter :: cpsw    = shr_const_cpsw        ! specific heat of sea h2o ~ J/kg/K
   real(R8),parameter :: rhosw   = shr_const_rhosw       ! density of sea water ~ kg/m^3
@@ -342,7 +342,6 @@ CONTAINS
 
     call seq_timemgr_EClockGetData( EClock, curr_ymd=CurrentYMD, curr_tod=CurrentTOD)
 
-    write_restart = .false.
     call docn_comp_run(EClock, x2o, o2x, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, logunit, read_restart, write_restart, &
@@ -353,7 +352,7 @@ CONTAINS
 
     call t_adj_detailf(-2)
 
-    if (dbug > 1 .and. my_task == master_task) then
+    if (dbug > 0 .and. my_task == master_task) then
        do n = 1,lsize
           write(logunit,F06)'n,ofrac = ',mct_aVect_indexRA(ggrid%data,'frac')
        end do
@@ -613,7 +612,7 @@ CONTAINS
     ! Debug output
     !----------------------------------------------------------
 
-    if (dbug > 1 .and. my_task == master_task) then
+    if (dbug > 0 .and. my_task == master_task) then
        do n = 1,lsize
           write(logunit,F01)'import: ymd,tod,n,Foxx_swnet = ', target_ymd, target_tod, n, x2o%rattr(kswnet,n)    
           write(logunit,F01)'import: ymd,tod,n,Foxx_lwup  = ', target_ymd, target_tod, n, x2o%rattr(klwup,n)    

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -118,7 +118,7 @@ module ESM
     use NUOPC                 , only : NUOPC_CompSetInternalEntryPoint, NUOPC_CompAttributeGet
     use NUOPC_Driver          , only : NUOPC_DriverAddComp
     use MED                   , only : med_SS => SetServices
-    use esmFlds               , only : esmFlds_Init, esmFlds_Concat
+    use esmFlds               , only : esmFlds_Init
     use seq_comm_mct          , only : CPLID, GLOID, ATMID, LNDID, OCNID, ICEID, GLCID, ROFID, WAVID, ESPID
     use seq_comm_mct          , only : num_inst_total
     use seq_comm_mct          , only : seq_comm_init, seq_comm_printcomms, seq_comm_petlist
@@ -515,10 +515,6 @@ module ESM
            write(logunit,*) trim(subname)//":wav_present="//trim(wav_present)
            write(logunit,*) trim(subname)//":glc_present="//trim(glc_present)
            write(logunit,*) trim(subname)//":med_present="//trim(med_present)
-
-           ! Print out colon delimited string of fields from mediator log file
-           call esmFlds_Concat(logunit, rc)
-           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
         end if
 
       else

--- a/src/drivers/nuopc/cime_flds/esmFlds.F90
+++ b/src/drivers/nuopc/cime_flds/esmFlds.F90
@@ -31,7 +31,6 @@ module esmFlds
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_AddMetaData
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_AddFld
   use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_AddMap
-  use shr_nuopc_fldList_mod , only : shr_nuopc_fldList_Concat
   use shr_nuopc_methods_mod , only : shr_nuopc_methods_chkerr
   use seq_drydep_mod        , only : seq_drydep_init, seq_drydep_readnl, lnd_drydep
   use shr_megan_mod         , only : shr_megan_readnl, shr_megan_mechcomps_n
@@ -50,7 +49,6 @@ module esmFlds
   !----------------------------------------------------------------------------
 
   public :: esmFlds_Init
-  public :: esmFlds_Concat
 
   !-----------------------------------------------
   ! Component and mapping array indices
@@ -2532,7 +2530,7 @@ contains
           call shr_nuopc_fldList_AddMap(fldListFr(complnd)%flds(n1), complnd, compatm, mapconsf, 'one', lnd2atm_smapname)
        enddo
     endif
-    call seq_drydep_init( )
+    call seq_drydep_init() ! TODO: remove this when all components call it separately
 
     !-----------------------------------------------------------------------------
     ! Nitrogen Deposition fields
@@ -2560,69 +2558,5 @@ contains
     end if
 
   end subroutine esmFlds_Init
-
-  !================================================================================
-
-  subroutine esmFlds_Concat(logunit, rc)
-
-    !----------------------------------------------------------------------------
-    ! creation of colon delimited field list
-    !----------------------------------------------------------------------------
-
-    ! input/output variables
-    integer, intent(in)    :: logunit
-    integer, intent(inout) :: rc
-
-    ! local variables
-    character(CXX) :: concatFr, concatTo
-    character(len=*), parameter :: subname='(esmFlds_Concat)'
-    !--------------------------------------
-
-    rc = ESMF_SUCCESS
-
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(compatm), fldListTo(compatm), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_a2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2a        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(complnd), fldListTo(complnd), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_l2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2l        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(compice), fldListTo(compice), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_i2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2i        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(compocn), fldListTo(compocn), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_o2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2o        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(compglc), fldListTo(compglc), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_g2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2g        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(comprof), fldListTo(comprof), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_r2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2r        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-    concatFr = ''; concatTo = ''
-    call shr_nuopc_fldList_Concat(fldListFr(compwav), fldListTo(compwav), concatFr, concatTo, flds_scalar_name)
-    write(logunit, "(A)") subname//': flds_w2x        = ',trim(concatFr)
-    write(logunit, "(A)") '-------------------------------------------------'
-    write(logunit, "(A)") subname//': flds_x2w        = ',trim(concatTo)
-    write(logunit, "(A)") '-------------------------------------------------'
-
-  end subroutine esmFlds_Concat
 
 end module esmFlds

--- a/src/drivers/nuopc/mediator/med_phases_ocnalb_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_ocnalb_mod.F90
@@ -247,23 +247,6 @@ contains
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Do not call med_phases again for target tod
-    call ESMF_GridCompGet(gcomp, clock=clock, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_ClockGet( clock, currTime=currTime, rc=rc )
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet( currTime, s=tod, rc=rc )
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (first_call) then
-       tod_last = tod
-    else
-       if (tod == tod_last) then
-          write(logunit,*)'Already created ocean albedos for tod= ',tod,' returning' 
-          RETURN
-       end if
-    end if
-
     ! Note that in the mct version the atm was initialized first so
     ! that nextsw_cday could be passed to the other components - this
     ! assumed that atmosphere component was ALWAYS initialized first.

--- a/src/drivers/nuopc/mediator/med_phases_ocnalb_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_ocnalb_mod.F90
@@ -1,4 +1,5 @@
 module med_phases_ocnalb_mod
+
   use med_constants_mod, only : R8
 
   implicit none
@@ -29,64 +30,57 @@ module med_phases_ocnalb_mod
      real(r8) , pointer :: avsdr (:) ! albedo: visible      , direct
      real(r8) , pointer :: anidf (:) ! albedo: near infrared, diffuse
      real(r8) , pointer :: avsdf (:) ! albedo: visible      , diffuse
-     real(r8) , pointer :: swndr (:) ! direct near-infrared  incident solar radiation
-     real(r8) , pointer :: swndf (:) ! diffuse near-infrared incident solar radiation
-     real(r8) , pointer :: swvdr (:) ! direct visible  incident solar radiation
-     real(r8) , pointer :: swvdf (:) ! diffuse visible incident solar radiation
-     real(r8) , pointer :: swdn  (:) ! short wave, downward (only used for diurnal calc)
-     real(r8) , pointer :: swup  (:) ! short wave, upward (only used for diurnal calc)
   end type ocnalb_type
 
   ! Conversion from degrees to radians
-  integer                :: dbrc
-  character(*),parameter :: u_FILE_u = __FILE__
+  character(*),parameter :: u_FILE_u = &
+       __FILE__
 
 !===============================================================================
 contains
 !===============================================================================
 
   subroutine med_phases_ocnalb_init(gcomp, ocnalb, rc)
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF, only : ESMF_GridComp, ESMF_VM, ESMF_Field, ESMF_Grid, ESMF_Mesh, ESMF_GeomType_Flag
-    use ESMF, only : ESMF_GridCompGet, ESMF_VMGet, ESMF_FieldGet, ESMF_GEOMTYPE_MESH
-    use ESMF, only : ESMF_MeshGet
-    use ESMF, only: operator(==)
-    use med_constants_mod, only : CL
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_getFieldN
-    use esmFlds               , only : compatm, compocn
-    use med_internalstate_mod , only : InternalState
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
-    use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
-
     !-----------------------------------------------------------------------
     ! Initialize pointers to the module variables and then use the module
     ! variables in the med_ocnalb phase
     ! All input field bundles are ASSUMED to be on the ocean grid
     !-----------------------------------------------------------------------
 
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
+    use ESMF                  , only : ESMF_GridComp, ESMF_VM, ESMF_Field, ESMF_Grid, ESMF_Mesh, ESMF_GeomType_Flag
+    use ESMF                  , only : ESMF_GridCompGet, ESMF_VMGet, ESMF_FieldGet, ESMF_GEOMTYPE_MESH
+    use ESMF                  , only : ESMF_MeshGet
+    use ESMF                  , only : operator(==)
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_getFieldN
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use med_internalstate_mod , only : InternalState
+    use med_constants_mod     , only : CL, R8
+    use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
+    use esmFlds               , only : compatm, compocn
+
     ! Arguments
-    type(ESMF_GridComp)              :: gcomp
-    type(ocnalb_type), intent(inout) :: ocnalb
-    integer, intent(out)             :: rc
+    type(ESMF_GridComp)               :: gcomp
+    type(ocnalb_type) , intent(inout) :: ocnalb
+    integer           , intent(out)   :: rc
     !
     ! Local variables
-    type(ESMF_VM)               :: vm
-    integer                           :: iam
-    type(ESMF_Field)            :: lfield
-    type(ESMF_Grid)             :: lgrid
-    type(ESMF_Mesh)             :: lmesh
-    type(ESMF_GeomType_Flag)    :: geomtype
-    integer                     :: n
-    integer                     :: lsize
-    real(R8), pointer :: rmask(:)  ! ocn domain mask
-    integer                     :: dimCount
-    integer                     :: spatialDim
-    integer                     :: numOwnedElements
-    type(InternalState)         :: is_local
-    real(R8), pointer :: ownedElemCoords(:)
-    character(len=CL)           :: tempc1,tempc2
-    character(*), parameter     :: subname = '(med_phases_ocnalb_init) '
+    type(ESMF_VM)            :: vm
+    integer                  :: iam
+    type(ESMF_Field)         :: lfield
+    type(ESMF_Mesh)          :: lmesh
+    type(ESMF_GeomType_Flag) :: geomtype
+    integer                  :: n
+    integer                  :: lsize
+    integer                  :: dimCount
+    integer                  :: spatialDim
+    integer                  :: numOwnedElements
+    type(InternalState)      :: is_local
+    real(R8), pointer        :: ownedElemCoords(:)
+    character(len=CL)        :: tempc1,tempc2
+    integer                  :: dbrc
+    character(*), parameter  :: subname = '(med_phases_ocnalb_init) '
     !-----------------------------------------------------------------------
 
     if (dbug_flag > 5) then
@@ -113,15 +107,6 @@ contains
     ! These must must be on the ocean grid since the ocean albedo computation is on the ocean grid
     ! The following sets pointers to the module arrays
 
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), fldname='Faxa_swndr', fldptr1=ocnalb%swndr, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), fldname='Faxa_swndf', fldptr1=ocnalb%swndf, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), fldname='Faxa_swvdr', fldptr1=ocnalb%swvdr, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), fldname='Faxa_swvdf', fldptr1=ocnalb%swvdf, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdr', fldptr1=ocnalb%avsdr, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdf', fldptr1=ocnalb%avsdf, rc=rc)
@@ -129,10 +114,6 @@ contains
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidr', fldptr1=ocnalb%anidr, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidf', fldptr1=ocnalb%anidf, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='Faox_swdn', fldptr1=ocnalb%swdn, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='Faox_swup', fldptr1=ocnalb%swup, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !----------------------------------
@@ -154,7 +135,7 @@ contains
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_MeshGet(lmesh, spatialDim=spatialDim, numOwnedElements=numOwnedElements, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       lsize = size(ocnalb%swndr)
+       lsize = size(ocnalb%anidr)
        if (numOwnedElements /= lsize) then
           write(tempc1,'(i10)') numOwnedElements
           write(tempc2,'(i10)') lsize
@@ -187,63 +168,72 @@ contains
   !===============================================================================
 
   subroutine med_phases_ocnalb_run(gcomp, rc)
+
+    !-----------------------------------------------------------------------
     ! Compute ocean albedos (on the ocean grid)
-    use ESMF, only : ESMF_GridComp, ESMF_Clock, ESMF_Time
-    use ESMF, only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFoundError
-    use ESMF, only : ESMF_LOGERR_PASSTHRU, ESMF_RouteHandleIsCreated, ESMF_LOGMSG_ERROR, ESMF_FAILURE
-    use NUOPC, only : NUOPC_CompAttributeGet
-    use med_constants_mod          , only : CS, CL
+    !-----------------------------------------------------------------------
+
+    use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time, ESMF_TimeInterval
+    use ESMF                  , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFoundError
+    use ESMF                  , only : ESMF_RouteHandleIsCreated
+    use ESMF                  , only : operator(+)
+    use NUOPC                 , only : NUOPC_CompAttributeGet
     use shr_const_mod         , only : shr_const_pi
     use shr_sys_mod           , only : shr_sys_abort
     use shr_orb_mod           , only : shr_orb_cosz, shr_orb_decl
-    use esmFlds               , only : flds_scalar_name
-    use esmFlds               , only : flds_scalar_num
-    use esmFlds               , only : flds_scalar_index_nextsw_cday
-    use esmFlds               , only : compatm, compocn
     use shr_nuopc_fldList_mod , only : mapconsf, mapnames
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_diagnose
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_State_GetScalar
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_FieldRegrid
-    use med_internalstate_mod , only : InternalState
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use med_constants_mod     , only : CS, CL, R8
     use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
+    use med_internalstate_mod , only : InternalState, logunit
+    use esmFlds               , only : flds_scalar_name
+    use esmFlds               , only : flds_scalar_num
+    use esmFlds               , only : flds_scalar_index_nextsw_cday
+    use esmFlds               , only : compatm, compocn
 
+    ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
     ! local variables
-    type(ocnalb_type), save       :: ocnalb
-    logical                       :: update_alb
-    type(InternalState)           :: is_local
-    type(ESMF_Clock)              :: clock
-    type(ESMF_Time)               :: currTime
-    character(CL)                 :: cvalue
-    character(CS)                 :: starttype        ! config start type
-    character(CL)                 :: runtype          ! initial, continue, hybrid, branch
-    character(CL)                 :: aoflux_grid
-    logical                       :: flux_albav       ! flux avg option
-    real(R8)            :: nextsw_cday      ! calendar day of next atm shortwave
-    real(R8), pointer   :: ofrac(:)
-    real(R8), pointer   :: ofrad(:)
-    real(R8), pointer   :: ifrac(:)
-    real(R8), pointer   :: ifrad(:)
-    integer                       :: lsize            ! local size
-    integer                       :: n,i              ! indices
-    real(R8)            :: rlat             ! gridcell latitude in radians
-    real(R8)            :: rlon             ! gridcell longitude in radians
-    real(R8)            :: cosz             ! Cosine of solar zenith angle
-    real(R8)            :: eccen            ! Earth orbit eccentricity
-    real(R8)            :: mvelpp           ! Earth orbit
-    real(R8)            :: lambm0           ! Earth orbit
-    real(R8)            :: obliqr           ! Earth orbit
-    real(R8)            :: delta            ! Solar declination angle  in radians
-    real(R8)            :: eccf             ! Earth orbit eccentricity factor
-    logical                       :: first_call = .true.
-    real(R8), parameter :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
-    real(R8), parameter :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
-    real(R8)    , parameter :: const_deg2rad = shr_const_pi/180.0_R8  ! deg to rads
+    type(ocnalb_type), save :: ocnalb
+    logical                 :: update_alb
+    type(InternalState)     :: is_local
+    type(ESMF_Clock)        :: clock
+    type(ESMF_Time)         :: currTime
+    type(ESMF_Time)         :: nextTime
+    type(ESMF_TimeInterval) :: timeStep
+    character(CL)           :: cvalue
+    character(CS)           :: starttype        ! config start type
+    character(CL)           :: runtype          ! initial, continue, hybrid, branch
+    character(CL)           :: aoflux_grid
+    logical                 :: flux_albav       ! flux avg option
+    real(R8)                :: nextsw_cday      ! calendar day of next atm shortwave
+    real(R8), pointer       :: ofrac(:)
+    real(R8), pointer       :: ofrad(:)
+    real(R8), pointer       :: ifrac(:)
+    real(R8), pointer       :: ifrad(:)
+    integer                 :: lsize            ! local size
+    integer                 :: n,i              ! indices
+    real(R8)                :: rlat             ! gridcell latitude in radians
+    real(R8)                :: rlon             ! gridcell longitude in radians
+    real(R8)                :: cosz             ! Cosine of solar zenith angle
+    real(R8)                :: eccen            ! Earth orbit eccentricity
+    real(R8)                :: mvelpp           ! Earth orbit
+    real(R8)                :: lambm0           ! Earth orbit
+    real(R8)                :: obliqr           ! Earth orbit
+    real(R8)                :: delta            ! Solar declination angle  in radians
+    real(R8)                :: eccf             ! Earth orbit eccentricity factor
+    real(R8), parameter     :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
+    real(R8), parameter     :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
+    real(R8), parameter     :: const_deg2rad = shr_const_pi/180.0_R8  ! deg to rads
+    integer                 :: dbrc
+    logical                 :: first_call = .true.
     character(len=*)  , parameter :: subname='(med_phases_ocnalb_run)'
     !---------------------------------------
 
@@ -257,6 +247,23 @@ contains
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    ! Do not call med_phases again for target tod
+    call ESMF_GridCompGet(gcomp, clock=clock, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_ClockGet( clock, currTime=currTime, rc=rc )
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet( currTime, s=tod, rc=rc )
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if (first_call) then
+       tod_last = tod
+    else
+       if (tod == tod_last) then
+          write(logunit,*)'Already created ocean albedos for tod= ',tod,' returning' 
+          RETURN
+       end if
+    end if
+
     ! Note that in the mct version the atm was initialized first so
     ! that nextsw_cday could be passed to the other components - this
     ! assumed that atmosphere component was ALWAYS initialized first.
@@ -265,11 +272,12 @@ contains
 
     if (first_call) then
 
+       ! Initialize ocean albedo calculation
        call med_phases_ocnalb_init(gcomp, ocnalb, rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call NUOPC_CompAttributeGet(gcomp, name='start_type', value=cvalue, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) starttype
 
        if (trim(starttype) == trim('startup')) then
@@ -282,13 +290,14 @@ contains
           call shr_sys_abort( subname//' ERROR: unknown starttype' )
        end if
 
+       call ESMF_GridCompGet(gcomp, clock=clock)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        if (trim(runtype) == 'initial') then
-          call ESMF_GridCompGet(gcomp, clock=clock)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-          call ESMF_ClockGet( clock, currTime=currTime, rc=rc )
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
           call ESMF_TimeGet( currTime, dayOfYear_r8=nextsw_cday, rc=rc )
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        else
           call shr_nuopc_methods_State_GetScalar(is_local%wrap%NstateImp(compatm), &
                flds_scalar_name=flds_scalar_name, flds_scalar_num=flds_scalar_num, &
@@ -315,52 +324,15 @@ contains
     call NUOPC_CompAttributeGet(gcomp, name='orb_eccen', value=cvalue, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) eccen
-
     call NUOPC_CompAttributeGet(gcomp, name='orb_obliqr', value=cvalue, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) obliqr
-
     call NUOPC_CompAttributeGet(gcomp, name='orb_lambm0', value=cvalue, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) lambm0
-
     call NUOPC_CompAttributeGet(gcomp, name='orb_mvelpp', value=cvalue, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) mvelpp
-
-    ! Map relevant atm fluxes to the ocean grid
-    ! NOTE: there are already pointers in place as module variables in med_ocnalb_mod.F90
-    ! to the arrays in FBMed_aoflux_o below - so do not need to pass them as arguments to med_ocnalb_run
-
-    if (ESMF_RouteHandleIsCreated(is_local%wrap%RH(compatm,compocn,mapconsf), rc=rc)) then
-       call shr_nuopc_methods_FB_FieldRegrid(&
-            is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdf', &
-            is_local%wrap%FBImp(compatm,compocn), 'Faxa_swvdf', &
-            is_local%wrap%RH(compatm,compocn,mapconsf), rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call shr_nuopc_methods_FB_FieldRegrid(&
-            is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndf', &
-            is_local%wrap%FBImp(compatm,compocn), 'Faxa_swndf', &
-            is_local%wrap%RH(compatm,compocn,mapconsf), rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call shr_nuopc_methods_FB_FieldRegrid(&
-            is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdr', &
-            is_local%wrap%FBImp(compatm,compocn), 'Faxa_swvdr', &
-            is_local%wrap%RH(compatm,compocn,mapconsf), rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call shr_nuopc_methods_FB_FieldRegrid(&
-            is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndr', &
-            is_local%wrap%FBImp(compatm,compocn), 'Faxa_swndr', &
-            is_local%wrap%RH(compatm,compocn,mapconsf), rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       call ESMF_LogWrite(trim(subname)//": ERROR RH not available for "//trim(mapnames(mapconsf)), &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-       rc = ESMF_FAILURE
-    end if
 
     ! Calculate ocean albedos on the ocean grid
 
@@ -376,20 +348,6 @@ contains
        end do
        update_alb = .true.
     else
-       ! need swdn & swup = swdn*(-albedo)
-       ! swdn & albedos are time-aligned  BEFORE albedos get updated below ---
-
-       do n=1,lsize
-          if ( ocnalb%anidr(n) == 1.0_r8 ) then ! dark side of earth
-             ocnalb%swup(n) = 0.0_r8
-             ocnalb%swdn(n) = 0.0_r8
-          else
-             ocnalb%swup(n) = ocnalb%swndr(n) * (-ocnalb%anidr(n)) + ocnalb%swndf(n) * (-ocnalb%anidf(n)) + &
-                              ocnalb%swvdr(n) * (-ocnalb%avsdr(n)) + ocnalb%swvdf(n) * (-ocnalb%avsdf(n))
-             ocnalb%swdn(n) = ocnalb%swndr(n) + ocnalb%swndf(n) + ocnalb%swvdr(n) + ocnalb%swvdf(n)
-          end if
-       end do
-
        ! Solar declination
        ! Will only do albedo calculation if nextsw_cday is not -1.
        if (nextsw_cday >= -0.5_r8) then
@@ -416,30 +374,9 @@ contains
              end if
           end do
           update_alb = .true.
+
        endif    ! nextsw_cday
     end if   ! flux_albav
-
-    ! If the aoflux grid is the atm - then need to map swdn and swup from the ocean grid (where
-    ! they were calculated to the atmosphere grid)
-    call NUOPC_CompAttributeGet(gcomp, name='aoflux_grid', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) aoflux_grid
-
-    if (trim(aoflux_grid) == 'atm') then
-       if (ESMF_RouteHandleIsCreated(is_local%wrap%RH(compocn,compatm,mapconsf), rc=rc)) then
-          call shr_nuopc_methods_FB_FieldRegrid(&
-               is_local%wrap%FBMed_ocnalb_o, 'Faox_swdn', &
-               is_local%wrap%FBMed_ocnalb_a, 'Faox_swdn', &
-               is_local%wrap%RH(compocn,compatm,mapconsf), rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          call shr_nuopc_methods_FB_FieldRegrid(&
-               is_local%wrap%FBMed_ocnalb_o, 'Faox_swup', &
-               is_local%wrap%FBMed_ocnalb_a, 'Faox_swup', &
-               is_local%wrap%RH(compocn,compatm,mapconsf), rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       end if
-    end if
 
     ! Update current ifrad/ofrad values if albedo was updated in field bundle
     if (update_alb) then
@@ -465,18 +402,20 @@ contains
   !===============================================================================
 
   subroutine med_phases_ocnalb_mapo2a(gcomp, rc)
-    use ESMF, only : ESMF_GridComp
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use med_map_mod           , only : med_map_FB_Regrid_Norm
-    use esmFlds               , only : fldListMed_ocnalb_o
-    use esmFlds               , only : compatm, compocn
-    use med_internalstate_mod , only : InternalState
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
-    use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
+
     !----------------------------------------------------------
     ! Map ocean albedos from ocn to atm grid
-    ! the med_phases routines
     !----------------------------------------------------------
+
+    use ESMF                  , only : ESMF_GridComp
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use med_map_mod           , only : med_map_FB_Regrid_Norm
+    use med_internalstate_mod , only : InternalState
+    use med_constants_mod     , only : R8
+    use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
+    use esmFlds               , only : fldListMed_ocnalb_o
+    use esmFlds               , only : compatm, compocn
 
     ! Arguments
     type(ESMF_GridComp)    :: gcomp
@@ -484,7 +423,7 @@ contains
 
     ! Local variables
     type(InternalState) :: is_local
-    integer :: dbrc
+    integer             :: dbrc
     character(*), parameter :: subName =   '(med_ocnalb_mapo2a) '
     !-----------------------------------------------------------------------
 

--- a/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
@@ -1,5 +1,6 @@
 module med_phases_prep_ocn_mod
-  use med_constants_mod       , only : dbug_flag=>med_constants_dbug_flag
+
+  use med_constants_mod, only : dbug_flag=>med_constants_dbug_flag
 
   !-----------------------------------------------------------------------------
   ! Carry out fast accumulation for the ocean
@@ -8,28 +9,28 @@ module med_phases_prep_ocn_mod
   implicit none
   private
 
-  character(*)      , parameter :: u_FILE_u  = __FILE__
-
-
   public :: med_phases_prep_ocn_map
   public :: med_phases_prep_ocn_merge
   public :: med_phases_prep_ocn_accum_fast
   public :: med_phases_prep_ocn_accum_avg
+
+  character(*), parameter :: u_FILE_u  = &
+       __FILE__
 
 !-----------------------------------------------------------------------------
 contains
 !-----------------------------------------------------------------------------
 
   subroutine med_phases_prep_ocn_map(gcomp, rc)
-    use ESMF, only : ESMF_GridComp, ESMF_Clock, ESMF_Time
-    use ESMF, only: ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF, only: ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockPrint
-    use ESMF, only: ESMF_FieldBundleGet
-    use med_internalstate_mod   , only : InternalState
-    use shr_nuopc_methods_mod   , only : shr_nuopc_methods_ChkErr
-    use med_map_mod             , only : med_map_FB_Regrid_Norm
-    use esmFlds                 , only : fldListFr
-    use esmFlds                 , only : compocn, ncomps, compname
+    use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF                  , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockPrint
+    use ESMF                  , only : ESMF_FieldBundleGet
+    use med_internalstate_mod , only : InternalState
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use med_map_mod           , only : med_map_FB_Regrid_Norm
+    use esmFlds               , only : fldListFr
+    use esmFlds               , only : compocn, ncomps, compname
 
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
@@ -95,20 +96,20 @@ contains
   !-----------------------------------------------------------------------------
 
   subroutine med_phases_prep_ocn_merge(gcomp, rc)
-    use ESMF, only : ESMF_GridComp, ESMF_FieldBundleGet
-    use ESMF, only: ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use shr_nuopc_methods_mod   , only : shr_nuopc_methods_ChkErr
-    use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_FldChk
-    use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_GetFldPtr
-    use shr_nuopc_methods_mod   , only : shr_nuopc_methods_FB_diagnose
 
-    use med_constants_mod, only : R8
-    use med_internalstate_mod   , only : InternalState, mastertask, logunit
-    use med_merge_mod           , only : med_merge_auto
-    use esmFlds                 , only : fldListTo
-    use esmFlds                 , only : compocn, compname, compatm, compice
+    use ESMF                  , only : ESMF_GridComp, ESMF_FieldBundleGet
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_FldChk
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_diagnose
+    use med_constants_mod     , only : R8
+    use med_internalstate_mod , only : InternalState, mastertask, logunit
+    use med_merge_mod         , only : med_merge_auto
+    use esmFlds               , only : fldListTo
+    use esmFlds               , only : compocn, compname, compatm, compice
 
-
+    ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -117,24 +118,23 @@ contains
     type(InternalState)         :: is_local
     integer                     :: n, n1, ncnt
     integer                     :: lsize
-    real(R8), pointer :: dataptr1(:)
-    real(R8), pointer :: ifrac(:), ofrac(:)
-    real(R8), pointer :: ifracr(:), ofracr(:)
-    real(R8), pointer :: avsdr(:), avsdf(:)
-    real(R8), pointer :: anidr(:), anidf(:)
-    real(R8), pointer :: swvdf(:), swndf(:)
-    real(R8), pointer :: swvdr(:), swndr(:)
-    real(R8), pointer :: swpen(:), swnet(:)
-    real(R8)          :: ifrac_scaled, ofrac_scaled
-    real(R8)          :: ifracr_scaled, ofracr_scaled
-    real(R8)          :: frac_sum
-    real(R8)          :: fswabsv, fswabsi
+    real(R8), pointer           :: dataptr1(:)
+    real(R8), pointer           :: ifrac(:), ofrac(:)
+    real(R8), pointer           :: ifracr(:), ofracr(:)
+    real(R8), pointer           :: avsdr(:), avsdf(:)
+    real(R8), pointer           :: anidr(:), anidf(:)
+    real(R8), pointer           :: swvdf(:), swndf(:)
+    real(R8), pointer           :: swvdr(:), swndr(:)
+    real(R8), pointer           :: swpen(:), swnet(:)
+    real(R8)                    :: ifrac_scaled, ofrac_scaled
+    real(R8)                    :: ifracr_scaled, ofracr_scaled
+    real(R8)                    :: frac_sum
+    real(R8)                    :: fswabsv, fswabsi
     character(len=*), parameter :: ice_fraction_name = 'Si_ifrac'
-    character(len=*), parameter :: subname='(med_phases_prep_ocn_merge)'
-    integer :: dbrc
-
+    integer                     :: dbrc
     ! TODO: the calculation needs to be set at run time based on receiving it from the ocean
-    real(R8)            :: flux_epbalfact = 1._R8
+    real(R8)                    :: flux_epbalfact = 1._R8
+    character(len=*), parameter :: subname='(med_phases_prep_ocn_merge)'
     !---------------------------------------
 
     if (dbug_flag > 5) then
@@ -228,14 +228,6 @@ contains
     if (shr_nuopc_methods_FB_FldChk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet',  swnet, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrad' , ifracr, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrad' , ofracr, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_avsdr' , avsdr, rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_anidr' , anidr, rc=rc)
@@ -254,33 +246,43 @@ contains
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        if (is_local%wrap%comp_present(compice)) then
+          call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrad' , ifracr, rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrad' , ofracr, rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
           call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen', swpen, rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 
-       do n = 1,size(ofrac)
-          ifrac_scaled = ifrac(n)
-          ofrac_scaled = ofrac(n)
-          frac_sum = ifrac(n) + ofrac(n)
-          if (frac_sum /= 0._R8) then
-             ifrac_scaled = ifrac(n) / (frac_sum)
-             ofrac_scaled = ofrac(n) / (frac_sum)
-          endif
-          ifracr_scaled = ifracr(n)
-          ofracr_scaled = ofracr(n)
-          frac_sum = ifracr(n) + ofracr(n)
-          if (frac_sum /= 0._R8) then
-             ifracr_scaled = ifracr(n) / (frac_sum)
-             ofracr_scaled = ofracr(n) / (frac_sum)
-          endif
-          fswabsv =  swvdr(n) * (1.0_R8 - avsdr(n)) + swvdf(n) * (1.0_R8 - avsdf(n))
-          fswabsi =  swndr(n) * (1.0_R8 - anidr(n)) + swndf(n) * (1.0_R8  - anidf(n))
+       do n = 1,size(swnet)
+          fswabsv  = swvdr(n) * (1.0_R8 - avsdr(n)) + swvdf(n) * (1.0_R8 - avsdf(n))
+          fswabsi  = swndr(n) * (1.0_R8 - anidr(n)) + swndf(n) * (1.0_R8 - anidf(n))
+          swnet(n) = fswabsv + fswabsi
+
           if (is_local%wrap%comp_present(compice)) then
-             swnet(n) = ofracr_scaled*(fswabsv + fswabsi) + ifrac_scaled*swpen(n)
-          else
-             swnet(n) = ofracr_scaled*(fswabsv + fswabsi)
-             swnet(n) = ofracr_scaled*(fswabsv + fswabsi)
+             ifrac_scaled = ifrac(n)
+             ofrac_scaled = ofrac(n)
+             frac_sum = ifrac(n) + ofrac(n)
+             if (frac_sum /= 0._R8) then
+                ifrac_scaled = ifrac(n) / (frac_sum)
+                ofrac_scaled = ofrac(n) / (frac_sum)
+             endif
+
+             ifracr_scaled = ifracr(n)
+             ofracr_scaled = ofracr(n)
+             frac_sum = ifracr(n) + ofracr(n)
+             if (frac_sum /= 0._R8) then
+                ifracr_scaled = ifracr(n) / (frac_sum)
+                ofracr_scaled = ofracr(n) / (frac_sum)
+             endif
+
+             swnet(n) = ofracr_scaled*swnet(n) + ifrac_scaled*swpen(n)
           end if
+
           ! if (i2o_per_cat) then
           !   Sf_ofrac(n)  = ofrac(n)
           !   Sf_ofracr(n) = ofracr(n)

--- a/src/drivers/nuopc/mediator/med_phases_restart_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_restart_mod.F90
@@ -18,30 +18,30 @@ contains
 !=================================================================================
 
   subroutine med_phases_restart_write(gcomp, rc)
-    use ESMF, only: ESMF_GridComp, ESMF_VM, ESMF_Clock, ESMF_Time
-    use ESMF, only: ESMF_TimeInterval, ESMF_CalKind_Flag, ESMF_MAXSTR
-    use ESMF, only: ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
-    use ESMF, only: ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF, only: ESMF_LOGMSG_ERROR, operator(==), operator(-)
-    use ESMF, only: ESMF_GridCompGet, ESMF_VMGet, ESMF_ClockGet, ESMF_ClockGetNextTime
-    use ESMF, only: ESMF_TimeGet, ESMF_ClockPrint, ESMF_TimeIntervalGet
-    use ESMF, only: ESMF_FieldBundleIsCreated
-    use med_constants_mod, only : dbug_flag => med_constants_dbug_flag
-    use med_constants_mod, only : SecPerDay => med_constants_SecPerDay
-    use med_constants_mod, only : med_constants_noleap
-    use med_constants_mod, only : med_constants_gregorian
-    use med_constants_mod, only : R8
-    use NUOPC, only : NUOPC_CompAttributeGet
-    use esmFlds                 , only : ncomps, compname
-    use shr_nuopc_methods_mod   , only : shr_nuopc_methods_ChkErr
-    use seq_timemgr_mod         , only : seq_timemgr_AlarmIsOn
-    use seq_timemgr_mod         , only : seq_timemgr_AlarmSetOff, seq_timemgr_alarm_restart
-    use med_internalstate_mod   , only : InternalState
-    use med_infodata_mod        , only : med_infodata, med_infodata_GetData
-    use shr_file_mod            , only : shr_file_getUnit, shr_file_freeUnit
-    use med_io_mod              , only : med_io_write, med_io_wopen, med_io_enddef
-    use med_io_mod              , only : med_io_close, med_io_date2yyyymmdd
-    use med_io_mod              , only : med_io_sec2hms
+    use ESMF                  , only : ESMF_GridComp, ESMF_VM, ESMF_Clock, ESMF_Time
+    use ESMF                  , only : ESMF_TimeInterval, ESMF_CalKind_Flag, ESMF_MAXSTR
+    use ESMF                  , only : ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
+    use ESMF                  , only : ESMF_LOGMSG_ERROR, operator(==), operator(-)
+    use ESMF                  , only : ESMF_GridCompGet, ESMF_VMGet, ESMF_ClockGet, ESMF_ClockGetNextTime
+    use ESMF                  , only : ESMF_TimeGet, ESMF_ClockPrint, ESMF_TimeIntervalGet
+    use ESMF                  , only : ESMF_FieldBundleIsCreated
+    use NUOPC                 , only : NUOPC_CompAttributeGet
+    use shr_file_mod          , only : shr_file_getUnit, shr_file_freeUnit
+    use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
+    use med_constants_mod     , only : SecPerDay => med_constants_SecPerDay
+    use med_constants_mod     , only : med_constants_noleap
+    use med_constants_mod     , only : med_constants_gregorian
+    use med_constants_mod     , only : R8
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use med_internalstate_mod , only : InternalState
+    use med_infodata_mod      , only : med_infodata, med_infodata_GetData
+    use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef
+    use med_io_mod            , only : med_io_close, med_io_date2yyyymmdd
+    use med_io_mod            , only : med_io_sec2hms
+    use esmFlds               , only : ncomps, compname, compocn
+    use seq_timemgr_mod       , only : seq_timemgr_AlarmIsOn 
+    use seq_timemgr_mod       , only : seq_timemgr_AlarmSetOff, seq_timemgr_alarm_restart
 
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
@@ -284,15 +284,13 @@ contains
              endif
           enddo
 
-          ! Write ocn albedo field bundle (CESM only)
-          ! if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o,rc=rc)) then
-          !    call med_infodata_GetData(med_infodata, ncomp=compocn, nx=nx, ny=ny)
-          !    !write(tmpstr,*) subname,' nx,ny = ',trim(compname(n)),nx,ny
-          !    !call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-          !    call med_io_write(restart_file, iam, is_local%wrap%FBMed_ocnalb_o, &
-          !         nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='MedOcnAlb_o', rc=rc)
-          !    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          ! end if
+          !Write ocn albedo field bundle (CESM only)
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o,rc=rc)) then
+             call med_infodata_GetData(med_infodata, ncomp=compocn, nx=nx, ny=ny)
+             call med_io_write(restart_file, iam, is_local%wrap%FBMed_ocnalb_o, &
+                  nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='MedOcnAlb_o', rc=rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          end if
 
        enddo
 
@@ -466,12 +464,12 @@ contains
        endif
     enddo
 
-    ! read ocn albedo field bundle (CESM only)
-    ! if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o,rc=rc)) then
-    !    call med_io_read(restart_file, mpicom, iam, is_local%wrap%FBMed_ocnalb_o, &
-    !         pre='MedOcnAlb_o', rc=rc)
-    !    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    ! end if
+    ! Read ocn albedo field bundle (CESM only)
+    if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o,rc=rc)) then
+       call med_io_read(restart_file, mpicom, iam, is_local%wrap%FBMed_ocnalb_o, &
+            pre='MedOcnAlb_o', rc=rc)
+       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     !---------------------------------------
     !--- clean up


### PR DESCRIPTION
NUOPC DTEST restart capability has been broken. This PR fixes this issue.

The following externals were used:

```
    ./cime
        clean sandbox, mvertens/fix_bugs2 --> origin/nuopc-cmeps
    ./components/cam
        clean sandbox, cam1/branches/nuopc_cap/components/cam --> cam1/branch_tags/nuopc_cap_tags/nuopc_cap_n17_cam6_0_002/components/cam
    ./components/cice
        clean sandbox, on mvertens/nuopc_cap (aecc3ca)
   ./components/clm 
        clean sandbox, on mvertens/nuopc_cap (f36db6b)
    ./components/clm/src/fates
        clean sandbox, on fates_s1.8.1_a3.0.0
    ./components/clm/tools/PTCLM
        clean sandbox, on PTCLM2_180214
    ./components/mom
        clean sandbox, on 837470f1e4cc95605fd57acd00c2c3149fd7a2e8
    ./components/mom/MOM6
        clean sandbox, on 8fd077b35cc3e5fbc652a876feab81e351437899
    ./components/mom/MOM6/pkg/MOM6_DA_hooks
        clean sandbox, on 6d8834ca8cf399f1a0d202239d72919907f6cd74
    ./components/mom/MOM6/pkg/geoKdTree
        clean sandbox, on a4670b9743c883d310d821eeac5b1f77f587b9d5
    ./components/mosart
        clean sandbox, on mvertens/nuopc_cap
    ./libraries/CVMix
        clean sandbox, on v0.92-beta
    ./libraries/FMS
        clean sandbox, on 4a198e65401ba605e0fc44d1a2c0f4c9166dd6b4
    ./libraries/FMS/src
        clean sandbox, on warsaw_201803
```
The following failures were observed (see comments)

```
    # the following are not failures in the restart - but failures in that the mom files are not being copied over to the
    # baseline directory
        FAIL ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io COMPARE_base_rest
        FAIL ERS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel.mom-nuopc_cap COMPARE_base_rest
        FAIL ERS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel.mom-nuopc_cap RUN time=607
```

```
    # expected baseline failure given that DTEST restart is now passing
      this is to be expected since the restart test was failing for the baseline and the compare is done in the restart phase - so new baselines must be generated 
        FAIL ERS_Vnuopc_Ld5.T62_g37.DTEST.cheyenne_intel.cice-nuopc_cap BASELINE restart_cime5.6.8

```
```
    # X compsets - any different order in the advertise phases or removal of fields will lead to differences in the X compsets - we should resolve this - but this should not effect this PR (the field list is in a slightly different order)
      FAIL ERS_Vnuopc_Ln9.f19_g16.X.cheyenne_intel BASELINE restart_cime5.6.8
      FAIL SMS_Vnuopc.f19_g16.X.cheyenne_intel     BASELINE restart_cime5.6.8
```

```
    # The following MCT tests really should not be done - since the driver and code has been kludged to compare with nuopc - the key issue for the MCT tests is to compare the smoke tests to verify either roundoff or bfb between NUOPC and MCT:
      FAIL ERR_Vmct_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io COMPARE_base_rest
      FAIL ERS_Vmct_Ld5.T62_g16.CMOM.cheyenne_intel.mom-nuopc_cap COMPARE_base_rest
      FAIL ERS_Vmct_Ld5.T62_g16.GMOM.cheyenne_intel.mom-nuopc_cap RUN time=605
      FAIL ERS_Vmct_Ln9.f19_g16.X.cheyenne_intel COMPARE_base_rest
```

Test suite: testlist_cmeps.xml
Test baseline: restart_cime5.6.8
Test namelist changes: no
Test status: bit for bit (except the following)
Fixes None
User interface changes?: No
Update gh-pages html (Y/N)?: No
Code review: 
