### PR TITLE
Mpicom cleanup

### DIFF
--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -61,8 +61,6 @@ def create_namelists(self, component=None):
 
     logger.info("Creating component namelists")
 
-    cime_model = self.get_value("MODEL")
-
     # Create namelists - must have cpl last in the list below
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts

--- a/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/data_comps/datm/nuopc/atm_comp_nuopc.F90
@@ -432,15 +432,15 @@ contains
     call shr_nuopc_grid_ArrayToState(a2x%rattr, flds_a2x, exportState, grid_option='mesh', rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDATM%nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDATM%nxg),flds_scalar_index_nx, exportState,  &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDATM%nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDATM%nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -605,7 +605,7 @@ contains
     call shr_nuopc_grid_ArrayToState(a2x%rattr, flds_a2x, exportState, grid_option='mesh', rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState,  &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/components/data_comps/dice/nuopc/ice_comp_nuopc.F90
+++ b/src/components/data_comps/dice/nuopc/ice_comp_nuopc.F90
@@ -392,11 +392,11 @@ contains
 
     nx_global = SDICE%nxg
     ny_global = SDICE%nyg
-    call shr_nuopc_methods_State_SetScalar(dble(nx_global),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nx_global),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(ny_global),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(ny_global),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/components/data_comps/dlnd/nuopc/lnd_comp_nuopc.F90
+++ b/src/components/data_comps/dlnd/nuopc/lnd_comp_nuopc.F90
@@ -357,11 +357,11 @@ contains
     call shr_nuopc_grid_ArrayToState(d2x%rattr, flds_l2x, exportState, grid_option='mesh', rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDLND%nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDLND%nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDLND%nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDLND%nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/components/data_comps/docn/nuopc/ocn_comp_nuopc.F90
+++ b/src/components/data_comps/docn/nuopc/ocn_comp_nuopc.F90
@@ -386,11 +386,11 @@ module ocn_comp_nuopc
     call shr_nuopc_grid_ArrayToState(o2x%rattr, flds_o2x, exportState, grid_option='mesh', rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDOCN%nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDOCN%nxg),flds_scalar_index_nx, exportState,  &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDOCN%nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDOCN%nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/components/data_comps/drof/nuopc/rof_comp_nuopc.F90
+++ b/src/components/data_comps/drof/nuopc/rof_comp_nuopc.F90
@@ -340,11 +340,11 @@ contains
     call shr_nuopc_grid_ArrayToState(r2x%rattr, flds_r2x, exportState, 'mesh', rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDROF%nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDROF%nxg),flds_scalar_index_nx, exportState,  &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDROF%nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDROF%nyg),flds_scalar_index_ny, exportState,  &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/components/data_comps/dwav/nuopc/wav_comp_nuopc.F90
+++ b/src/components/data_comps/dwav/nuopc/wav_comp_nuopc.F90
@@ -344,11 +344,11 @@ contains
     call shr_nuopc_grid_ArrayToState(w2x%rattr, flds_w2x, exportState, grid_option='mesh', rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDWAV%nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDWAV%nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(SDWAV%nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(SDWAV%nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/components/xcpl_comps/xatm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xatm/nuopc/atm_comp_nuopc.F90
@@ -56,14 +56,12 @@ module atm_comp_nuopc
   character(CXX)             :: flds_x2a = ''
   integer                    :: nxg                  ! global dim i-direction
   integer                    :: nyg                  ! global dim j-direction
-  integer                    :: mpicom               ! mpi communicator
-  integer                    :: my_task              ! my task in mpi communicator mpicom
+  integer                    :: my_task              ! my task in mpi communicator
   integer                    :: inst_index           ! number of current instance (ie. 1)
   character(len=12)          :: inst_name            ! fullname of current instance (ie. "lnd_0001")
   character(len=5)          :: inst_suffix      ! char string associated with instance (ie. "_0001" or "")
   integer                    :: logunit              ! logging unit number
   logical :: mastertask
-  integer                    :: dbrc
   logical                    :: atm_prognostic
 
   !----- formats -----
@@ -81,7 +79,8 @@ module atm_comp_nuopc
     character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! the NUOPC gcomp component will register the generic methods
     call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
@@ -113,7 +112,8 @@ module atm_comp_nuopc
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine SetServices
 
@@ -130,7 +130,6 @@ module atm_comp_nuopc
 
     ! local variables
     type(ESMF_VM)      :: vm
-    integer            :: lmpicom
     character(CL)      :: cvalue
     character(CS)      :: stdname
     integer            :: n
@@ -145,19 +144,14 @@ module atm_comp_nuopc
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
-
-    !----------------------------------------------------------------------------
-    ! generate local mpi comm
-    !----------------------------------------------------------------------------
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, localpet=my_task, rc=rc)
+    call ESMF_VMGet(vm, localpet=my_task, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call mpi_comm_dup(lmpicom, mpicom, ierr)
     mastertask = my_task==0
     !----------------------------------------------------------------------------
     ! determine instance information
@@ -279,7 +273,7 @@ module atm_comp_nuopc
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeAdvertise
 
@@ -303,7 +297,7 @@ module atm_comp_nuopc
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -318,7 +312,7 @@ module atm_comp_nuopc
     ! generate the mesh
     !--------------------------------
 
-    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, mpicom, gindex, lon, lat, Emesh, rc)
+    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, gindex, lon, lat, Emesh, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -360,11 +354,11 @@ module atm_comp_nuopc
        end if
     end do
 
-    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -375,7 +369,7 @@ module atm_comp_nuopc
     call ESMF_TimeGet(nextTime, dayOfYear_r8=nextsw_cday)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -408,7 +402,7 @@ module atm_comp_nuopc
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeRealize
 
@@ -432,7 +426,7 @@ module atm_comp_nuopc
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call shr_nuopc_memcheck(subname, 3, mastertask)
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
@@ -484,7 +478,7 @@ module atm_comp_nuopc
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_nuopc_methods_State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, &
-         mpicom, flds_scalar_name, flds_scalar_num, rc)
+          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -502,7 +496,7 @@ module atm_comp_nuopc
     if(mastertask) then
        call shr_nuopc_log_clock_advance(clock, 'ATM', logunit)
     endif
-    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelAdvance
 
@@ -521,11 +515,11 @@ module atm_comp_nuopc
     !--------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call dead_final_nuopc('atm', logunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelFinalize
 

--- a/src/components/xcpl_comps/xatm/nuopc/atm_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xatm/nuopc/atm_comp_nuopc.F90
@@ -223,7 +223,7 @@ module atm_comp_nuopc
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_dstdry4'  , flds_concat=flds_a2x)
 
        do n = 1,fldsFrAtm_num
-          write(logunit,*)'Advertising From Xatm ',trim(fldsFrAtm(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising From Xatm ',trim(fldsFrAtm(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrAtm(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -256,7 +256,7 @@ module atm_comp_nuopc
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_evap' , flds_concat=flds_x2a)
 
        do n = 1,fldsToAtm_num
-          write(logunit,*)'Advertising To Xatm',trim(fldsToAtm(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising To Xatm',trim(fldsToAtm(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToAtm(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/xcpl_comps/xglc/nuopc/glc_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xglc/nuopc/glc_comp_nuopc.F90
@@ -202,7 +202,7 @@ contains
        call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Flgg_hflx'                 , flds_concat=flds_g2x)
 
        do n = 1,fldsFrGlc_num
-          write(logunit,*)'Advertising From Xglc ',trim(fldsFrGlc(n)%stdname)
+          if (mastertask) write(logunit,*)'Advertising From Xglc ',trim(fldsFrGlc(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrglc(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -220,7 +220,7 @@ contains
        end do
 
        do n = 1,fldsToGlc_num
-          write(logunit,*)'Advertising To Xglc ',trim(fldsToGlc(n)%stdname)
+          if (mastertask) write(logunit,*)'Advertising To Xglc ',trim(fldsToGlc(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToglc(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/xcpl_comps/xglc/nuopc/glc_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xglc/nuopc/glc_comp_nuopc.F90
@@ -30,7 +30,6 @@ module glc_comp_nuopc
   use dead_nuopc_mod        , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
   use dead_nuopc_mod        , only : state_getimport, state_setexport
   use dead_nuopc_mod        , only : ModelInitPhase, ModelSetRunClock, Print_FieldExchInfo
-
   implicit none
   private ! except
 
@@ -54,7 +53,6 @@ module glc_comp_nuopc
   character(CXX)             :: flds_x2g = ''
   integer                    :: nxg                  ! global dim i-direction
   integer                    :: nyg                  ! global dim j-direction
-  integer                    :: mpicom               ! mpi communicator
   integer                    :: my_task              ! my task in mpi communicator mpicom
   integer                    :: inst_index           ! number of current instance (ie. 1)
   character(len=16)          :: inst_name            ! fullname of current instance (ie. "glc_0001")
@@ -64,7 +62,6 @@ module glc_comp_nuopc
   logical :: mastertask
   character(len=*),parameter :: grid_option = "mesh" ! grid_de, grid_arb, grid_reg, mesh
   integer, parameter         :: dbug = 10
-  integer                    :: dbrc
   character(*),parameter     :: modName =  "(xglc_comp_nuopc)"
   character(*),parameter     :: u_FILE_u = __FILE__
 
@@ -78,42 +75,41 @@ contains
     character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! the NUOPC gcomp component will register the generic methods
     call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    ! switching to IPD versions
     call ESMF_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
          userRoutine=ModelInitPhase, phase=0, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! set entry point for methods that require specific implementation
-    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      phaseLabelList=(/"IPDv01p1"/), userRoutine=InitializeAdvertise, rc=rc)
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, phaseLabelList=(/"IPDv01p1"/), &
+         userRoutine=InitializeAdvertise, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      phaseLabelList=(/"IPDv01p3"/), userRoutine=InitializeRealize, rc=rc)
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, phaseLabelList=(/"IPDv01p3"/), &
+         userRoutine=InitializeRealize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! attach specializing method(s)
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, &
-      specRoutine=ModelAdvance, rc=rc)
+    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, specRoutine=ModelAdvance, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, &
-      specRoutine=ModelSetRunClock, rc=rc)
+    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, specRoutine=ModelSetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, &
-      specRoutine=ModelFinalize, rc=rc)
+    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine SetServices
 
@@ -131,7 +127,6 @@ contains
 
     ! local variables
     type(ESMF_VM)      :: vm
-    integer            :: lmpicom
     character(CL)      :: cvalue
     character(CS)      :: stdname
     character(CS)      :: nec_str
@@ -150,19 +145,14 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
-
-    !----------------------------------------------------------------------------
-    ! generate local mpi comm
-    !----------------------------------------------------------------------------
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, localpet=my_task, rc=rc)
+    call ESMF_VMGet(vm, localpet=my_task, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call mpi_comm_dup(lmpicom, mpicom, ierr)
     mastertask = my_task == master_task
 
     !----------------------------------------------------------------------------
@@ -200,7 +190,7 @@ contains
     call NUOPC_CompAttributeGet(gcomp, name='glc_nec', value=cvalue, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) glc_nec
-    call ESMF_LogWrite('glc_nec = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite('glc_nec = '// trim(cvalue), ESMF_LOGMSG_INFO, rc=rc)
 
     if (nxg /= 0 .and. nyg /= 0) then
 
@@ -240,7 +230,7 @@ contains
        allocate(x2d(FldsToGlc_num,lsize)); x2d(:,:)  = 0._r8
     end if
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to original values
@@ -269,7 +259,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -284,7 +274,7 @@ contains
     ! grid_option specifies grid or mesh
     !--------------------------------
 
-    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, mpicom, gindex, lon, lat, Emesh, rc)
+    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, gindex, lon, lat, Emesh, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -326,11 +316,11 @@ contains
        end if
     end do
 
-    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -363,7 +353,7 @@ contains
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeRealize
 
@@ -384,7 +374,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call shr_nuopc_memcheck(subname, 3, mastertask)
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
@@ -450,7 +440,7 @@ contains
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelAdvance
 
@@ -469,11 +459,11 @@ contains
     !--------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call dead_final_nuopc('glc', logunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelFinalize
 

--- a/src/components/xcpl_comps/xice/nuopc/ice_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xice/nuopc/ice_comp_nuopc.F90
@@ -216,7 +216,7 @@ module ice_comp_nuopc
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_flxdst'   , flds_concat=flds_i2x)
 
        do n = 1,fldsFrIce_num
-          write(logunit,*)'Advertising From Xice ',trim(fldsFrIce(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising From Xice ',trim(fldsFrIce(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrIce(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -257,7 +257,7 @@ module ice_comp_nuopc
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_dstwet4'  , flds_concat=flds_x2i)
 
        do n = 1,fldsToIce_num
-          write(logunit,*)'Advertising To Xice ',trim(fldsToIce(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising To Xice ',trim(fldsToIce(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToIce(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/xcpl_comps/xice/nuopc/ice_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xice/nuopc/ice_comp_nuopc.F90
@@ -56,7 +56,6 @@ module ice_comp_nuopc
   character(CXX)             :: flds_x2i = ''
   integer                    :: nxg                  ! global dim i-direction
   integer                    :: nyg                  ! global dim j-direction
-  integer                    :: mpicom               ! mpi communicator
   integer                    :: my_task              ! my task in mpi communicator mpicom
   integer                    :: inst_index           ! number of current instance (ie. 1)
   character(len=16)          :: inst_name            ! fullname of current instance (ie. "ice_0001")
@@ -65,7 +64,6 @@ module ice_comp_nuopc
   integer    ,parameter      :: master_task=0        ! task number of master task
   logical :: mastertask
   character(len=*),parameter :: grid_option = "mesh" ! grid_de, grid_arb, grid_reg, mesh
-  integer                    :: dbrc
   character(*),parameter     :: modName =  "(xice_comp_nuopc)"
   character(*),parameter     :: u_FILE_u = &
        __FILE__
@@ -73,14 +71,14 @@ module ice_comp_nuopc
   !===============================================================================
   contains
   !===============================================================================
-
   subroutine SetServices(gcomp, rc)
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
     character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! the NUOPC gcomp component will register the generic methods
     call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
@@ -106,19 +104,19 @@ module ice_comp_nuopc
 
     call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, specRoutine=ModelSetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine SetServices
 
-  !===============================================================================
 
+  !===============================================================================
   subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     use shr_nuopc_utils_mod, only : shr_nuopc_set_component_logging
     use shr_nuopc_utils_mod, only : shr_nuopc_get_component_instance
@@ -130,7 +128,6 @@ module ice_comp_nuopc
 
     ! local variables
     type(ESMF_VM)      :: vm
-    integer            :: lmpicom
     character(CL)      :: cvalue
     character(CS)      :: stdname
     integer            :: n
@@ -145,19 +142,14 @@ module ice_comp_nuopc
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
-
-    !----------------------------------------------------------------------------
-    ! generate local mpi comm
-    !----------------------------------------------------------------------------
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, localpet=my_task, rc=rc)
+    call ESMF_VMGet(vm, localpet=my_task, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call mpi_comm_dup(lmpicom, mpicom, ierr)
     mastertask = my_task == master_task
 
     !----------------------------------------------------------------------------
@@ -276,7 +268,7 @@ module ice_comp_nuopc
     end if
 
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to original values
@@ -305,7 +297,7 @@ module ice_comp_nuopc
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -320,7 +312,7 @@ module ice_comp_nuopc
     ! generate the mesh
     !--------------------------------
 
-    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, mpicom, gindex, lon, lat, Emesh, rc)
+    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, gindex, lon, lat, Emesh, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -362,11 +354,11 @@ module ice_comp_nuopc
        end if
     end do
 
-    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -399,7 +391,7 @@ module ice_comp_nuopc
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeRealize
 
@@ -420,7 +412,7 @@ module ice_comp_nuopc
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call shr_nuopc_memcheck(subname, 3, mastertask)
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
@@ -485,7 +477,7 @@ module ice_comp_nuopc
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelAdvance
 
@@ -504,11 +496,11 @@ module ice_comp_nuopc
     !--------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call dead_final_nuopc('ice', logunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelFinalize
 

--- a/src/components/xcpl_comps/xlnd/nuopc/lnd_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xlnd/nuopc/lnd_comp_nuopc.F90
@@ -214,7 +214,7 @@ contains
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_flxdst4'  , flds_concat=flds_l2x)
 
        do n = 1,fldsFrLnd_num
-          write(logunit,*)'Advertising From Xlnd ',trim(fldsFrLnd(n)%stdname)
+          if (mastertask) write(logunit,*)'Advertising From Xlnd ',trim(fldsFrLnd(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrLnd(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -256,7 +256,7 @@ contains
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_dstwet4' , flds_concat=flds_x2l)
 
        do n = 1,fldsToLnd_num
-          write(logunit,*)'Advertising To Xlnd',trim(fldsToLnd(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising To Xlnd',trim(fldsToLnd(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToLnd(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/xcpl_comps/xlnd/nuopc/lnd_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xlnd/nuopc/lnd_comp_nuopc.F90
@@ -56,7 +56,6 @@ module lnd_comp_nuopc
   character(CXX)             :: flds_x2l = ''
   integer                    :: nxg                  ! global dim i-direction
   integer                    :: nyg                  ! global dim j-direction
-  integer                    :: mpicom               ! mpi communicator
   integer                    :: my_task              ! my task in mpi communicator mpicom
   integer                    :: inst_index           ! number of current instance (ie. 1)
   character(len=16)          :: inst_name            ! fullname of current instance (ie. "lnd_0001")
@@ -65,22 +64,21 @@ module lnd_comp_nuopc
   integer    ,parameter      :: master_task=0        ! task number of master task
   logical :: mastertask
   character(len=*),parameter :: grid_option = "mesh" ! grid_de, grid_arb, grid_reg, mesh
-  integer                    :: dbrc
   character(*),parameter     :: modName =  "(xlnd_comp_nuopc)"
   character(*),parameter     :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
 contains
-!===============================================================================
-
+  !===============================================================================
   subroutine SetServices(gcomp, rc)
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
     character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! the NUOPC gcomp component will register the generic methods
     call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
@@ -92,12 +90,12 @@ contains
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! set entry point for methods that require specific implementation
-    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      phaseLabelList=(/"IPDv01p1"/), userRoutine=InitializeAdvertise, rc=rc)
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, phaseLabelList=(/"IPDv01p1"/), &
+         userRoutine=InitializeAdvertise, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      phaseLabelList=(/"IPDv01p3"/), userRoutine=InitializeRealize, rc=rc)
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, phaseLabelList=(/"IPDv01p3"/), &
+         userRoutine=InitializeRealize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! attach specializing method(s)
@@ -112,12 +110,11 @@ contains
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine SetServices
-
   !===============================================================================
-
   subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     use shr_nuopc_utils_mod, only : shr_nuopc_set_component_logging
     use shr_nuopc_utils_mod, only : shr_nuopc_get_component_instance
@@ -129,7 +126,6 @@ contains
 
     ! local variables
     type(ESMF_VM)      :: vm
-    integer            :: lmpicom
     character(CL)      :: cvalue
     character(CS)      :: stdname
     integer            :: n
@@ -144,19 +140,14 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
-
-    !----------------------------------------------------------------------------
-    ! generate local mpi comm
-    !----------------------------------------------------------------------------
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, localpet=my_task, rc=rc)
+    call ESMF_VMGet(vm, localpet=my_task, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call mpi_comm_dup(lmpicom, mpicom, ierr)
     mastertask = my_task == master_task
 
     !----------------------------------------------------------------------------
@@ -170,7 +161,7 @@ contains
     ! set logunit and set shr logging to my log file
     !----------------------------------------------------------------------------
 
-    call shr_nuopc_set_component_logging(gcomp, my_task==master_task, logunit, shrlogunit, shrloglev)
+    call shr_nuopc_set_component_logging(gcomp, mastertask, logunit, shrlogunit, shrloglev)
 
     !----------------------------------------------------------------------------
     ! Initialize xlnd
@@ -305,7 +296,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -320,7 +311,7 @@ contains
     ! generate the mesh
     !--------------------------------
 
-    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, mpicom, gindex, lon, lat, Emesh, rc)
+    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, gindex, lon, lat, Emesh, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -362,11 +353,11 @@ contains
        end if
     end do
 
-    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -375,7 +366,7 @@ contains
     !--------------------------------
 
     if (dbug > 1) then
-       if (my_task == master_task) then
+       if (mastertask) then
           call Print_FieldExchInfo(values=d2x, logunit=logunit, &
                fldlist=fldsFrLnd, nflds=fldsFrLnd_num, istr="InitializeRealize: lnd->mediator")
        end if
@@ -399,7 +390,7 @@ contains
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeRealize
 
@@ -420,7 +411,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call shr_nuopc_memcheck(subname, 3, mastertask)
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
@@ -473,21 +464,21 @@ contains
     !--------------------------------
 
     if (dbug > 1) then
-       if (my_task == master_task) then
+       if (mastertask) then
           call Print_FieldExchInfo(values=d2x, logunit=logunit, &
                fldlist=fldsFrLnd, nflds=fldsFrLnd_num, istr="ModelAdvance: lnd->mediator")
        end if
        call shr_nuopc_methods_State_diagnose(exportState,subname//':ES',rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
-    if(my_task == master_task) then
+    if(mastertask) then
        call shr_nuopc_log_clock_advance(clock, 'LND', logunit)
     endif
 
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelAdvance
 
@@ -506,11 +497,11 @@ contains
     !--------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call dead_final_nuopc('lnd', logunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelFinalize
 

--- a/src/components/xcpl_comps/xocn/nuopc/ocn_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xocn/nuopc/ocn_comp_nuopc.F90
@@ -140,7 +140,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! generate local mpi comm
@@ -201,7 +201,7 @@ contains
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, "Fioo_q"        , flds_concat=flds_o2x)
 
        do n = 1,fldsFrOcn_num
-          write(logunit,*)'Advertising From Xocn ',trim(fldsFrOcn(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising From Xocn ',trim(fldsFrOcn(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrOcn(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -227,7 +227,7 @@ contains
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Sa_pslv"       , flds_concat=flds_x2o)
 
        do n = 1,fldsToOcn_num
-          write(logunit,*)'Advertising To Xocn',trim(fldsToOcn(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising To Xocn',trim(fldsToOcn(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToOcn(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -237,7 +237,7 @@ contains
        allocate(x2d(FldsToOcn_num,lsize)); x2d(:,:)  = 0._r8
     end if
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to original values

--- a/src/components/xcpl_comps/xocn/nuopc/ocn_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xocn/nuopc/ocn_comp_nuopc.F90
@@ -55,7 +55,6 @@ module ocn_comp_nuopc
   character(CXX)             :: flds_x2o = ''
   integer                    :: nxg                  ! global dim i-direction
   integer                    :: nyg                  ! global dim j-direction
-  integer                    :: mpicom               ! mpi communicator
   integer                    :: my_task              ! my task in mpi communicator mpicom
   integer                    :: inst_index           ! number of current instance (ie. 1)
   character(len=16)          :: inst_name            ! fullname of current instance (ie. "ocn_0001")
@@ -64,21 +63,20 @@ module ocn_comp_nuopc
   integer    ,parameter      :: master_task=0        ! task number of master task
   logical :: mastertask
   character(len=*),parameter :: grid_option = "mesh" ! grid_de, grid_arb, grid_reg, mesh
-  integer                    :: dbrc
   character(*),parameter     :: modName =  "(xocn_comp_nuopc)"
   character(*),parameter     :: u_FILE_u = __FILE__
 
 !===============================================================================
 contains
-!===============================================================================
-
+  !===============================================================================
   subroutine SetServices(gcomp, rc)
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
     character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! the NUOPC gcomp component will register the generic methods
     call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
@@ -99,20 +97,19 @@ contains
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! attach specializing method(s)
-
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, specRoutine=ModelAdvance, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, specRoutine=ModelSetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine SetServices
 
@@ -129,7 +126,6 @@ contains
 
     ! local variables
     type(ESMF_VM)      :: vm
-    integer            :: lmpicom
     character(CL)      :: cvalue
     character(CS)      :: stdname
     integer            :: n
@@ -144,7 +140,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! generate local mpi comm
@@ -153,10 +149,9 @@ contains
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, localpet=my_task, rc=rc)
+    call ESMF_VMGet(vm, localpet=my_task, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call mpi_comm_dup(lmpicom, mpicom, ierr)
     mastertask = my_task == master_task
 
     !----------------------------------------------------------------------------
@@ -242,7 +237,7 @@ contains
        allocate(x2d(FldsToOcn_num,lsize)); x2d(:,:)  = 0._r8
     end if
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to original values
@@ -271,7 +266,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -286,7 +281,7 @@ contains
     ! generate the mesh
     !--------------------------------
 
-    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, mpicom, gindex, lon, lat, Emesh, rc)
+    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, gindex, lon, lat, Emesh, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -328,11 +323,11 @@ contains
        end if
     end do
 
-    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -365,7 +360,7 @@ contains
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeRealize
 
@@ -386,7 +381,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call shr_nuopc_memcheck(subname, 3, mastertask)
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
@@ -452,7 +447,7 @@ contains
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelAdvance
 
@@ -471,11 +466,11 @@ contains
     !--------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call dead_final_nuopc('ocn', logunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelFinalize
 

--- a/src/components/xcpl_comps/xrof/nuopc/rof_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xrof/nuopc/rof_comp_nuopc.F90
@@ -190,7 +190,7 @@ contains
        call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_volrmch')
 
        do n = 1,fldsFrRof_num
-          write(logunit,*)'Advertising From Xrof ',trim(fldsFrRof(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising From Xrof ',trim(fldsFrRof(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrRof(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -205,7 +205,7 @@ contains
        call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_irrig')
 
        do n = 1,fldsToRof_num
-          write(logunit,*)'Advertising To Xrof',trim(fldsToRof(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising To Xrof',trim(fldsToRof(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToRof(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/xcpl_comps/xrof/nuopc/rof_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xrof/nuopc/rof_comp_nuopc.F90
@@ -55,8 +55,7 @@ module rof_comp_nuopc
   character(CXX)             :: flds_x2r = ''
   integer                    :: nxg                  ! global dim i-direction
   integer                    :: nyg                  ! global dim j-direction
-  integer                    :: mpicom               ! mpi communicator
-  integer                    :: my_task              ! my task in mpi communicator mpicom
+  integer                    :: my_task              ! my task in mpi
   integer                    :: inst_index           ! number of current instance (ie. 1)
   character(len=16)          :: inst_name            ! fullname of current instance (ie. "rof_0001")
   character(len=16)          :: inst_suffix = ""     ! char string associated with instance (ie. "_0001" or "")
@@ -64,7 +63,6 @@ module rof_comp_nuopc
   integer    ,parameter      :: master_task=0        ! task number of master task
   logical :: mastertask
   character(len=*),parameter :: grid_option = "mesh" ! grid_de, grid_arb, grid_reg, mesh
-  integer                    :: dbrc
   character(*),parameter     :: modName =  "(xrof_comp_nuopc)"
   character(*),parameter     :: u_FILE_u = &
        __FILE__
@@ -72,21 +70,21 @@ module rof_comp_nuopc
 !===============================================================================
 contains
 !===============================================================================
-
   subroutine SetServices(gcomp, rc)
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
     character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! the NUOPC gcomp component will register the generic methods
     call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! switching to IPD versions
-    call ESMF_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE,  &
+    call ESMF_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
          userRoutine=ModelInitPhase, phase=0, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -100,25 +98,22 @@ contains
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! attach specializing method(s)
-
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, specRoutine=ModelAdvance, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, specRoutine=ModelSetRunClock, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine SetServices
-
-  !===============================================================================
-
+!===============================================================================
   subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     use shr_nuopc_utils_mod, only : shr_nuopc_set_component_logging
     use shr_nuopc_utils_mod, only : shr_nuopc_get_component_instance
@@ -129,7 +124,6 @@ contains
 
     ! local variables
     type(ESMF_VM)      :: vm
-    integer            :: lmpicom
     character(CL)      :: cvalue
     character(CS)      :: stdname
     integer            :: n
@@ -144,19 +138,14 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
-
-    !----------------------------------------------------------------------------
-    ! generate local mpi comm
-    !----------------------------------------------------------------------------
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, localpet=my_task, rc=rc)
+    call ESMF_VMGet(vm, localpet=my_task, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call mpi_comm_dup(lmpicom, mpicom, ierr)
     mastertask = my_task == master_task
 
     !----------------------------------------------------------------------------
@@ -170,7 +159,7 @@ contains
     ! set logunit and set shr logging to my log file
     !----------------------------------------------------------------------------
 
-    call shr_nuopc_set_component_logging(gcomp, my_task==master_task, logunit, shrlogunit, shrloglev)
+    call shr_nuopc_set_component_logging(gcomp, mastertask, logunit, shrlogunit, shrloglev)
 
     !----------------------------------------------------------------------------
     ! Initialize xrof
@@ -226,7 +215,7 @@ contains
        allocate(x2d(FldsToRof_num,lsize)); x2d(:,:)  = 0._r8
     end if
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to original values
@@ -255,7 +244,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -270,7 +259,7 @@ contains
     ! generate the mesh
     !--------------------------------
 
-    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, mpicom, gindex, lon, lat, Emesh, rc)
+    call shr_nuopc_grid_MeshInit(gcomp, nxg, nyg, gindex, lon, lat, Emesh, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------
@@ -312,11 +301,11 @@ contains
        end if
     end do
 
-    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nxg),flds_scalar_index_nx, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, mpicom, &
+    call shr_nuopc_methods_State_SetScalar(dble(nyg),flds_scalar_index_ny, exportState, &
          flds_scalar_name, flds_scalar_num, rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -325,7 +314,7 @@ contains
     !--------------------------------
 
     if (dbug > 1) then
-       if (my_task == master_task) then
+       if (mastertask) then
           call Print_FieldExchInfo(values=d2x, logunit=logunit, &
                fldlist=fldsFrRof, nflds=fldsFrRof_num, istr="InitializeRealize: rof->mediator")
        end if
@@ -349,7 +338,7 @@ contains
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine InitializeRealize
 
@@ -370,7 +359,7 @@ contains
 
     !-------------------------------------------------------------------------------
     rc = ESMF_SUCCESS
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call shr_nuopc_memcheck(subname, 3, mastertask)
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
@@ -421,21 +410,21 @@ contains
     !--------------------------------
 
     if (dbug > 1) then
-       if (my_task == master_task) then
+       if (mastertask) then
           call Print_FieldExchInfo(values=d2x, logunit=logunit, &
                fldlist=fldsFrRof, nflds=fldsFrRof_num, istr="ModelAdvance: rof->mediator")
        end if
        call shr_nuopc_methods_State_diagnose(exportState,subname//':ES',rc=rc)
        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
-    if(my_task == master_task) then
+    if(mastertask) then
        call shr_nuopc_log_clock_advance(clock, 'ROF', logunit)
     endif
 
     call shr_file_setLogLevel(shrloglev)
     call shr_file_setLogUnit (shrlogunit)
 
-    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelAdvance
 
@@ -454,11 +443,11 @@ contains
     !--------------------------------
 
     rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
 
     call dead_final_nuopc('rof', logunit)
 
-    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+    if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine ModelFinalize
 

--- a/src/components/xcpl_comps/xwav/nuopc/wav_comp_nuopc.F90
+++ b/src/components/xcpl_comps/xwav/nuopc/wav_comp_nuopc.F90
@@ -162,7 +162,7 @@ contains
     ! set logunit and set shr logging to my log file
     !----------------------------------------------------------------------------
 
-    call shr_nuopc_set_component_logging(gcomp, my_task==master_task, logunit, shrlogunit, shrloglev)
+    call shr_nuopc_set_component_logging(gcomp, mastertask, logunit, shrlogunit, shrloglev)
 
     !----------------------------------------------------------------------------
     ! Initialize xwav
@@ -191,7 +191,7 @@ contains
        call fld_list_add(fldsFrWav_num, fldsFrWav, 'Sw_hstokes' , flds_concat=flds_w2x)
 
        do n = 1,fldsFrWav_num
-          write(logunit,*)'Advertising From Xwav ',trim(fldsFrWav(n)%stdname)
+          if (mastertask) write(logunit,*)'Advertising From Xwav ',trim(fldsFrWav(n)%stdname)
           call NUOPC_Advertise(exportState, standardName=fldsFrWav(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -208,7 +208,7 @@ contains
        call fld_list_add(fldsToWav_num, fldsToWav, 'So_bldepth' , flds_concat=flds_x2w)
 
        do n = 1,fldsToWav_num
-          write(logunit,*)'Advertising To Xwav ',trim(fldsToWav(n)%stdname)
+          if(mastertask) write(logunit,*)'Advertising To Xwav ',trim(fldsToWav(n)%stdname)
           call NUOPC_Advertise(importState, standardName=fldsToWav(n)%stdname, &
                TransferOfferGeomObject='will provide', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -1645,14 +1645,8 @@ module ESM
     character(CL) :: timing_dir        ! timing directory
     character(len=5) :: inst_suffix
     logical :: isPresent
-    type(ESMF_VM) :: vm
-    integer       :: mpicomm
 
     rc = ESMF_SUCCESS
-    call ESMF_GridCompGet(driver, vm=vm, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMGet(vm, mpiCommunicator=mpicomm, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompAttributeGet(driver, name="timing_dir",value=timing_dir, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1665,8 +1659,6 @@ module ESM
     else
        inst_suffix = ""
     endif
-    call t_prf(trim(timing_dir)//'/model_timing'//trim(inst_suffix), &
-         mpicom=mpicomm)
 
     call t_finalizef()
 

--- a/src/drivers/nuopc/cime_flds/esmFlds.F90
+++ b/src/drivers/nuopc/cime_flds/esmFlds.F90
@@ -63,15 +63,12 @@ contains
     integer           :: ice_ncat                   ! number of sea ice thickness categories
     integer           :: glc_nec                    ! number of land-ice elevation classes
     integer           :: max_megan
-    integer           :: max_ddep   
+    integer           :: max_ddep
     integer           :: max_fire
     logical           :: flds_i2o_per_cat
     integer           :: dbrc
-    type(ESMF_VM)     :: vm
-    integer           :: localPet
     integer           :: num, i, n
     integer           :: n1, n2, n3, n4
-    integer           :: mpicom
     character(len=3)  :: cnum
     character(len=CL) :: cvalue
     character(len=CS) :: name, fldname
@@ -120,16 +117,10 @@ contains
     max_ddep  = 80
     max_fire  = 10
     glc_nec   = 10
-    ice_ncat  =  5 
+    ice_ncat  =  5
     flds_i2o_per_cat = .true.
 
     rc = ESMF_SUCCESS
-
-    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_VMGet(vm, localPet=localPet, mpiCommunicator=mpicom, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompAttributeGet(gcomp, name='flds_co2a', value=cvalue, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1328,7 +1319,7 @@ contains
     end if
 
     !-----------------------------
-    ! lnd -> glc  
+    ! lnd -> glc
     !-----------------------------
 
     ! glc fields with multiple elevation classes: lnd->glc
@@ -1468,7 +1459,7 @@ contains
     !--------------------------------------------
     ! Atmospheric specific humidty at lowest level:
     !--------------------------------------------
-    
+
     call shr_nuopc_fldList_AddFld(fldListFr(compatm)%flds, 'Sa_shum_16O', fldindex=n1)
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, complnd, mapbilnr, 'one', atm2lnd_smapname)
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, compice, mapbilnr, 'one', atm2ice_smapname)
@@ -1572,7 +1563,7 @@ contains
     !-------------
     ! Isotopic snow:
     !-------------
-    
+
     call shr_nuopc_fldList_AddFld(fldListFr(compatm)%flds, 'Faxa_snowl_16O', fldindex=n1)
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, complnd, mapbilnr, 'one', atm2lnd_smapname)
     call shr_nuopc_fldList_AddMap(fldListFr(compatm)%flds(n1), compatm, compice, mapconsf, 'one', atm2ice_fmapname)

--- a/src/drivers/nuopc/mediator/med.F90
+++ b/src/drivers/nuopc/mediator/med.F90
@@ -646,7 +646,6 @@ contains
 
     ! Realize connected Fields with transfer action "provide"
 
-    use MPI                   , only : MPI_Comm_Dup
     use ESMF                  , only : ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_VM, ESMF_SUCCESS
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_TimeInterval
     use ESMF                  , only : ESMF_VMGet, ESMF_StateIsCreated, ESMF_GridCompGet
@@ -667,7 +666,6 @@ contains
     integer                    :: i, j
     real(kind=R8),pointer      :: lonPtr(:), latPtr(:)
     type(InternalState)        :: is_local
-    integer                    :: lmpicom
     real(R8)                   :: intervalSec
     type(ESMF_TimeInterval)    :: timeStep
     ! tcx XGrid
@@ -693,9 +691,7 @@ contains
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize the internal state members
-    call ESMF_VMGet(vm, mpiCommunicator=lmpicom, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call MPI_Comm_Dup(lmpicom, is_local%wrap%mpicom, stat)
+    is_local%wrap%vm = vm
 
     ! Realize States
     do n = 1,ncomps
@@ -1750,7 +1746,7 @@ contains
              if (atCorrectTime) then
                 if (fieldNameList(n) == flds_scalar_name) then
                    call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(n1), med_infodata, &
-                        trim(compname(n1))//'2cpli', is_local%wrap%mpicom, rc)
+                        trim(compname(n1))//'2cpli', is_local%wrap%vm, rc)
                    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
                    call ESMF_LogWrite(trim(subname)//" MED - Initialize-Data-Dependency CSTI "//trim(compname(n1)), &
                         ESMF_LOGMSG_INFO, rc=rc)

--- a/src/drivers/nuopc/mediator/med_connectors_mod.F90
+++ b/src/drivers/nuopc/mediator/med_connectors_mod.F90
@@ -7,10 +7,9 @@ module med_connectors_mod
   use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_Failure
   use ESMF                  , only : ESMF_State, ESMF_Clock, ESMF_GridComp
   use med_internalstate_mod , only : InternalState
-  use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+  use shr_nuopc_utils_mod , only : shr_nuopc_utils_ChkErr
   use med_constants_mod     , only : spval => med_constants_spval
   use med_constants_mod     , only : czero => med_constants_czero
-  use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
 
   implicit none
   private
@@ -48,11 +47,8 @@ module med_connectors_mod
 contains
 !-----------------------------------------------------------------------------
 
-  subroutine med_connectors_prep_generic(gcomp, type, rc)
-
-    use ESMF                  , only : ESMF_GridCompGet
-    use esmFlds               , only : compatm, compocn, compice
-    use esmFlds               , only : complnd, comprof, compwav, compglc
+  subroutine med_connectors_prep_generic(gcomp, type, compid, rc)
+    use ESMF                  , only : ESMF_GridCompGet, ESMF_VMGet
     use med_infodata_mod      , only : med_infodata_CopyStateToInfodata
     use med_infodata_mod      , only : med_infodata_CopyInfodataToState
     use med_infodata_mod      , only : med_infodata
@@ -62,6 +58,7 @@ contains
     ! input/output variables
     type(ESMF_GridComp)          :: gcomp
     character(len=*), intent(in) :: type
+    integer, intent(in)          :: compid
     integer, intent(out)         :: rc
 
     ! local variables
@@ -71,143 +68,56 @@ contains
     logical             :: connected
     integer             :: n
     integer             :: dbrc
+    integer             :: mytask
+    character(len=10)   :: med2comp
+    character(len=7)    :: cpl2comp
     character(len=*),parameter :: subname='(med_connectors_prep_generic)'
     !---------------------------------------------
     call t_startf('MED:'//subname)
-
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//trim(type)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//trim(type)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
     ! query the Component for its clock, importState and exportState
     call ESMF_GridCompGet(gcomp, clock=clock, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Get the internal state from Component.
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-
+    call ESMF_VMGet(is_local%wrap%vm, localPet=mytask, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     !-------------------------
     ! diagnose export state
     ! update scalar data in Exp and Imp State
     !-------------------------
+    med2comp = "med_to_"//type
+    cpl2comp = "cpl2"//type
 
-    select case (type)
+    is_local%wrap%conn_prep_cnt(compid) = is_local%wrap%conn_prep_cnt(compid) + 1
+    call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(compid), value=spval, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(compid), is_local%wrap%FBExp(compid), rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_diagnose(is_local%wrap%NStateExp(compid), is_local%wrap%conn_prep_cnt(compid), med2comp, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(compid), cpl2comp, mytask, rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(compid), cpl2comp, mytask, rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    case('atm')
-      is_local%wrap%conn_prep_cnt(compatm) = is_local%wrap%conn_prep_cnt(compatm) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(compatm), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(compatm), is_local%wrap%FBExp(compatm), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(compatm), is_local%wrap%conn_prep_cnt(compatm), "med_to_atm", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(compatm),'cpl2atm',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(compatm),'cpl2atm',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_LogWrite(trim(subname)//trim(type)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
-    case('ocn')
-      is_local%wrap%conn_prep_cnt(compocn) = is_local%wrap%conn_prep_cnt(compocn) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(compocn), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(compocn), is_local%wrap%FBExp(compocn), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(compocn), is_local%wrap%conn_prep_cnt(compocn), "med_to_ocn", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(compocn),'cpl2ocn',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(compocn),'cpl2ocn',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('ice')
-      is_local%wrap%conn_prep_cnt(compice) = is_local%wrap%conn_prep_cnt(compice) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(compice), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(compice), is_local%wrap%FBExp(compice), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(compice), is_local%wrap%conn_prep_cnt(compice), "med_to_ice", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(compice),'cpl2ice',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(compice),'cpl2ice',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('lnd')
-      is_local%wrap%conn_prep_cnt(complnd) = is_local%wrap%conn_prep_cnt(complnd) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(complnd), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(complnd), is_local%wrap%FBExp(complnd), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(complnd), is_local%wrap%conn_prep_cnt(complnd), "med_to_lnd", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(complnd),'cpl2lnd',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(complnd),'cpl2lnd',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('rof')
-      is_local%wrap%conn_prep_cnt(comprof) = is_local%wrap%conn_prep_cnt(comprof) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(comprof), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(comprof), is_local%wrap%FBExp(comprof), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(comprof), is_local%wrap%conn_prep_cnt(comprof), "med_to_rof", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(comprof),'cpl2rof',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(comprof),'cpl2rof',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('wav')
-      is_local%wrap%conn_prep_cnt(compwav) = is_local%wrap%conn_prep_cnt(compwav) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(compwav), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(compwav), is_local%wrap%FBExp(compwav), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(compwav), is_local%wrap%conn_prep_cnt(compwav), "med_to_wav", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(compwav),'cpl2wav',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(compwav),'cpl2wav',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('glc')
-      is_local%wrap%conn_prep_cnt(compglc) = is_local%wrap%conn_prep_cnt(compglc) + 1
-      call shr_nuopc_methods_State_reset(is_local%wrap%NStateExp(compglc), value=spval, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%NStateExp(compglc), is_local%wrap%FBExp(compglc), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_connectors_diagnose(is_local%wrap%NStateExp(compglc), is_local%wrap%conn_prep_cnt(compglc), "med_to_glc", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateExp(compglc),'cpl2glc',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyInfodataToState(med_infodata,is_local%wrap%NStateImp(compglc),'cpl2glc',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case default
-      rc = ESMF_Failure
-      call ESMF_LogWrite(trim(subname)//trim(type)//" unsupported", ESMF_LOGMSG_INFO, rc=dbrc)
-
-    end select
-
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//trim(type)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
     call t_stopf('MED:'//subname)
 
   end subroutine med_connectors_prep_generic
 
   !-----------------------------------------------------------------------------
 
-  subroutine med_connectors_post_generic(gcomp, type, rc)
+  subroutine med_connectors_post_generic(gcomp, type, compid, rc)
 
     use ESMF                  , only : ESMF_GridCompGet
-    use esmFlds               , only : compatm, compocn, compice
-    use esmFlds               , only : complnd, comprof, compwav, compglc
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_copy
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_reset
     use med_infodata_mod      , only : med_infodata
@@ -216,126 +126,54 @@ contains
     ! input/output variables
     type(ESMF_GridComp)           :: gcomp
     character(len=*), intent(in)  :: type
+    integer,          intent(in)  :: compid
     integer,          intent(out) :: rc
 
     ! local variables
     type(ESMF_Clock)    :: clock
     type(InternalState) :: is_local
     integer             :: dbrc
+    character(len=10)   :: comp2med
+    character(len=7)    :: comp2cpl
     character(len=*),parameter :: subname='(med_connectors_post_generic)'
     !---------------------------------------------
 
     ! Note: for information obtained by the mediator always write out the state
     ! if statewrite_flag is .true.
+    rc = ESMF_SUCCESS
     call t_startf('MED:'//subname)
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//trim(type)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-    rc = ESMF_SUCCESS
+    call ESMF_LogWrite(trim(subname)//trim(type)//": called", ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! query the Component for its clock, importState and exportState
     call ESMF_GridCompGet(gcomp, clock=clock, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Get the internal state from Component.
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     !-------------------------
     ! diagnose import state
     ! copy import state scalar data to local datatype
     !-------------------------
+    comp2med = "med_from_"//type
+    comp2cpl = type//"2cpl"
 
-    select case (type)
+    is_local%wrap%conn_post_cnt(compid) = is_local%wrap%conn_post_cnt(compid) + 1
+    call med_connectors_diagnose(is_local%wrap%NStateImp(compid), is_local%wrap%conn_post_cnt(compid),comp2med, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(compid),med_infodata, comp2cpl ,is_local%wrap%vm,rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(compid,compid), value=czero, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(compid,compid), is_local%wrap%NStateImp(compid), rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    case('atm')
-      is_local%wrap%conn_post_cnt(compatm) = is_local%wrap%conn_post_cnt(compatm) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(compatm), is_local%wrap%conn_post_cnt(compatm), " med_from_atm", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(compatm),med_infodata,'atm2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(compatm,compatm), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(compatm,compatm), is_local%wrap%NStateImp(compatm), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_LogWrite(trim(subname)//trim(type)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
-    case('ocn')
-      is_local%wrap%conn_post_cnt(compocn) = is_local%wrap%conn_post_cnt(compocn) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(compocn), is_local%wrap%conn_post_cnt(compocn), " med_from_ocn", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(compocn),med_infodata,'ocn2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(compocn,compocn), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(compocn,compocn), is_local%wrap%NStateImp(compocn), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('ice')
-      is_local%wrap%conn_post_cnt(compice) = is_local%wrap%conn_post_cnt(compice) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(compice), is_local%wrap%conn_post_cnt(compice), " med_from_ice", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(compice),med_infodata,'ice2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(compice,compice), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(compice,compice), is_local%wrap%NStateImp(compice), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('lnd')
-      is_local%wrap%conn_post_cnt(complnd) = is_local%wrap%conn_post_cnt(complnd) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(complnd), is_local%wrap%conn_post_cnt(complnd), " med_from_lnd", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(complnd),med_infodata,'lnd2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(complnd,complnd), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(complnd,complnd), is_local%wrap%NStateImp(complnd), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('rof')
-      is_local%wrap%conn_post_cnt(comprof) = is_local%wrap%conn_post_cnt(comprof) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(comprof), is_local%wrap%conn_post_cnt(comprof), " med_from_rof", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(comprof),med_infodata,'rof2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(comprof,comprof), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(comprof,comprof), is_local%wrap%NStateImp(comprof), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('wav')
-      is_local%wrap%conn_post_cnt(compwav) = is_local%wrap%conn_post_cnt(compwav) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(compwav), is_local%wrap%conn_post_cnt(compwav), " med_from_wav", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(compwav),med_infodata,'wav2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(compwav,compwav), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(compwav,compwav), is_local%wrap%NStateImp(compwav), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case('glc')
-      is_local%wrap%conn_post_cnt(compglc) = is_local%wrap%conn_post_cnt(compglc) + 1
-      call med_connectors_diagnose(is_local%wrap%NStateImp(compglc), is_local%wrap%conn_post_cnt(compglc), " med_from_glc", rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call med_infodata_CopyStateToInfodata(is_local%wrap%NStateImp(compglc),med_infodata,'glc2cpl',is_local%wrap%mpicom,rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_reset(is_local%wrap%FBImp(compglc,compglc), value=czero, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_copy(is_local%wrap%FBImp(compglc,compglc), is_local%wrap%NStateImp(compglc), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    case default
-      rc = ESMF_Failure
-      call ESMF_LogWrite(trim(subname)//trim(type)//" unsupported", ESMF_LOGMSG_INFO, rc=dbrc)
-
-    end select
-
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//trim(type)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
     call t_stopf('MED:'//subname)
 
   end subroutine med_connectors_post_generic
@@ -344,6 +182,7 @@ contains
 
   subroutine med_connectors_prep_med2atm(gcomp, rc)
     use perf_mod, only : t_startf, t_stopf
+    use esmFlds,  only : compatm
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -353,17 +192,14 @@ contains
     !---------------------------------------------
     call t_startf('MED:'//subname)
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
+
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'atm', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'atm', compatm, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
     call t_stopf('MED:'//subname)
 
   end subroutine med_connectors_prep_med2atm
@@ -371,6 +207,7 @@ contains
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_prep_med2ocn(gcomp, rc)
+    use esmFlds,  only : compocn
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -379,23 +216,21 @@ contains
     character(len=*),parameter :: subname='(med_connectors_prep_med2ocn)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
+
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'ocn', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'ocn', compocn, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_prep_med2ocn
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_prep_med2ice(gcomp, rc)
+    use esmFlds,  only : compice
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -404,23 +239,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_prep_med2ice)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'ice', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'ice', compice, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_prep_med2ice
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_prep_med2lnd(gcomp, rc)
+    use esmFlds,  only : complnd
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -429,23 +261,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_prep_med2lnd)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'lnd', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'lnd', complnd, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_prep_med2lnd
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_prep_med2rof(gcomp, rc)
+    use esmFlds,  only : comprof
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -454,23 +283,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_prep_med2rof)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'rof', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'rof', comprof, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_prep_med2rof
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_prep_med2wav(gcomp, rc)
+    use esmFlds,  only : compwav
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -479,23 +305,21 @@ contains
     character(len=*),parameter :: subname='(med_connectors_prep_med2wav)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
+
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'wav', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'wav', compwav, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_prep_med2wav
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_prep_med2glc(gcomp, rc)
+    use esmFlds,  only : compglc
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -504,23 +328,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_prep_med2glc)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_prep_generic(gcomp, 'glc', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_prep_generic(gcomp, 'glc', compglc, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_prep_med2glc
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_atm2med(gcomp, rc)
+    use esmFlds,  only : compatm
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -529,23 +350,21 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_atm2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
+
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'atm', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'atm', compatm, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_atm2med
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_ocn2med(gcomp, rc)
+    use esmFlds,  only : compocn
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -554,23 +373,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_ocn2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'ocn', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'ocn', compocn, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_ocn2med
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_ice2med(gcomp, rc)
+    use esmFlds,  only : compice
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -579,23 +395,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_ice2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'ice', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'ice', compice, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_ice2med
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_lnd2med(gcomp, rc)
+    use esmFlds,  only : complnd
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -604,23 +417,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_lnd2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'lnd', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'lnd', complnd, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_lnd2med
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_rof2med(gcomp, rc)
+    use esmFlds,  only : comprof
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -629,23 +439,20 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_rof2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'rof', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'rof', comprof, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_rof2med
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_wav2med(gcomp, rc)
+    use esmFlds,  only : compwav
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -654,23 +461,21 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_wav2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
+
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'wav', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'wav', compwav, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_wav2med
 
   !-----------------------------------------------------------------------------
 
   subroutine med_connectors_post_glc2med(gcomp, rc)
+    use esmFlds,  only : compglc
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
@@ -679,17 +484,13 @@ contains
     character(len=*),parameter :: subname='(med_connectors_post_glc2med)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
-    call med_connectors_post_generic(gcomp, 'glc', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_connectors_post_generic(gcomp, 'glc', compglc, rc=rc)
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_post_glc2med
 
@@ -701,6 +502,7 @@ contains
     use NUOPC                 , only : NUOPC_Write
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_State_diagnose
     use med_constants_mod     , only : statewrite_flag => med_constants_statewrite_flag
+    use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
 
     ! input/output variables
     type(ESMF_State), intent(in)    :: State
@@ -715,18 +517,16 @@ contains
     character(len=*),parameter     :: subname='(med_connectors_diagnose)'
     !---------------------------------------------
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//trim(string)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//trim(string)//": called", ESMF_LOGMSG_INFO, rc=rc)
     rc = ESMF_SUCCESS
 
     call ESMF_StateGet(State, itemCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Obtain the field names in State - allocate memory which will be deallocated at the end
     allocate(fieldnamelist(fieldCount))
     call ESMF_StateGet(State, itemNameList=fieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 1) then
       call shr_nuopc_methods_State_diagnose(State, string=trim(subname)//trim(string), rc=rc)
@@ -734,19 +534,17 @@ contains
 
     ! Write out the fields in State to netcdf files
     if (cntr > 0 .and. statewrite_flag) then
-      call ESMF_LogWrite(trim(subname)//trim(string)//": writing out fields", ESMF_LOGMSG_INFO, rc=dbrc)
+      call ESMF_LogWrite(trim(subname)//trim(string)//": writing out fields", ESMF_LOGMSG_INFO, rc=rc)
       call NUOPC_Write(State, &
         fieldnamelist(1:fieldCount), &
         "field_"//trim(string)//"_", timeslice=cntr, &
         overwrite=.true., relaxedFlag=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
     deallocate(fieldnamelist)
 
-    if (dbug_flag > 5) then
-      call ESMF_LogWrite(trim(subname)//trim(string)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
+    call ESMF_LogWrite(trim(subname)//trim(string)//": done", ESMF_LOGMSG_INFO, rc=rc)
 
   end subroutine med_connectors_diagnose
 

--- a/src/drivers/nuopc/mediator/med_infodata_mod.F90
+++ b/src/drivers/nuopc/mediator/med_infodata_mod.F90
@@ -111,11 +111,12 @@ CONTAINS
   end subroutine med_infodata_init2
 
   !================================================================================
-  subroutine med_infodata_CopyStateToInfodata(State, infodata, type, mpicom, rc)
+  subroutine med_infodata_CopyStateToInfodata(State, infodata, type, vm, rc)
     use ESMF                  , only : ESMF_State, ESMF_Field, ESMF_StateItem_Flag
     use ESMF                  , only : ESMF_StateGet, ESMF_FieldGet, ESMF_LogWrite
     use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_INFO
     use ESMF                  , only : ESMF_STATEITEM_NOTFOUND, operator(==)
+    use ESMF                  , only : ESMF_VMBroadCast, ESMF_VM, ESMF_VMGet
     use esmFlds               , only : compname
     use shr_nuopc_scalars_mod , only : flds_scalar_num, flds_scalar_name
     use shr_nuopc_scalars_mod , only : flds_scalar_index_nx, flds_scalar_index_ny
@@ -123,9 +124,6 @@ CONTAINS
     use shr_nuopc_scalars_mod , only : flds_scalar_index_flood_present
     use shr_nuopc_scalars_mod , only : flds_scalar_index_rofice_present
     use shr_nuopc_scalars_mod , only : flds_scalar_index_precip_fact
-    ! use mpi                 , only : mpi_comm_rank, MPI_ERROR_STRING, mpi_bcast, mpi_real8, MPI_SUCCESS
-    ! use mpi                 , only : MPI_MAX_ERROR_STRING
-    use mpi  ! TODO - have an only for mpi_bcast does not work on hobart
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_chkErr
 
     ! ----------------------------------------------
@@ -136,13 +134,12 @@ CONTAINS
     type(ESMF_State),        intent(in)     :: State
     type(med_infodata_type), intent(inout)  :: infodata
     character(len=*),        intent(in)     :: type
-    integer,                 intent(in)     :: mpicom
+    type(ESMF_VM)                           :: vm
     integer,                 intent(inout)  :: rc
 
     ! local variables
     integer                         :: n
     integer                         :: mytask, ierr, len
-    character(MPI_MAX_ERROR_STRING) :: lstring
     type(ESMF_Field)                :: field
     type(ESMF_StateItem_Flag)       :: itemType
     real(R8), pointer               :: farrayptr(:,:)
@@ -154,8 +151,9 @@ CONTAINS
     !----------------------------------------------------------
 
     rc = ESMF_SUCCESS
+    call ESMF_VMGet(vm, localPet=mytask, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call MPI_COMM_RANK(mpicom, mytask, rc)
     call ESMF_StateGet(State, itemName=trim(flds_scalar_name), itemType=itemType, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -177,13 +175,8 @@ CONTAINS
         data(1:flds_scalar_num) = farrayptr(1,1:flds_scalar_num)
       endif
 
-      call MPI_BCAST(data, flds_scalar_num, MPI_REAL8, 0, mpicom, rc)
-      if (rc /= MPI_SUCCESS) then
-        call MPI_ERROR_STRING(rc,lstring,len,ierr)
-        call ESMF_LogWrite(trim(subname)//": ERROR "//trim(lstring), ESMF_LOGMSG_INFO, line=__LINE__, file=u_FILE_u, rc=dbrc)
-        rc = ESMF_FAILURE
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      endif
+      call ESMF_VMBroadCast(vm, data, flds_scalar_num, 0, rc=rc)
+      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       do n = 1,ncomps
          ntype = trim(compname(n))//'2cpli'
@@ -250,11 +243,10 @@ CONTAINS
   end subroutine med_infodata_CopyStateToInfodata
 
   !================================================================================
-  subroutine med_infodata_CopyInfodataToState(infodata, State, type, mpicom, rc)
+  subroutine med_infodata_CopyInfodataToState(infodata, State, type, mytask, rc)
     use ESMF                  , only : ESMF_State, ESMF_StateGet, ESMF_Field, ESMF_StateItem_Flag, ESMF_FieldGet
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_STATEITEM_NOTFOUND
     use ESMF                  , only : operator(==), ESMF_FAILURE
-    use mpi                   , only : mpi_comm_rank
     use shr_nuopc_scalars_mod , only : flds_scalar_num, flds_scalar_name
     use shr_nuopc_scalars_mod , only : flds_scalar_index_nx, flds_scalar_index_ny
     use shr_nuopc_scalars_mod , only : flds_scalar_index_nextsw_cday
@@ -269,11 +261,10 @@ CONTAINS
     type(med_infodata_type),intent(in):: infodata
     type(ESMF_State),  intent(inout)  :: State
     character(len=*),  intent(in)     :: type
-    integer,           intent(in)     :: mpicom
+    integer         ,  intent(in)     :: mytask
     integer,           intent(inout)  :: rc
 
     ! local variables
-    integer                     :: mytask
     type(ESMF_Field)            :: field
     type(ESMF_StateItem_Flag)   :: ItemType
     real(R8), pointer :: farrayptr(:,:)
@@ -283,8 +274,6 @@ CONTAINS
     !----------------------------------------------------------
 
     rc = ESMF_SUCCESS
-
-    call MPI_COMM_RANK(mpicom, mytask, rc)
 
     call ESMF_StateGet(State, itemName=trim(flds_scalar_name), itemType=itemType, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/drivers/nuopc/mediator/med_internalstate_mod.F90
+++ b/src/drivers/nuopc/mediator/med_internalstate_mod.F90
@@ -5,6 +5,7 @@ module med_internalstate_mod
   !-----------------------------------------------------------------------------
 
   use ESMF                  , only : ESMF_RouteHandle, ESMF_FieldBundle, ESMF_State
+  use ESMF                  , only : ESMF_VM
   use esmFlds               , only : ncomps
   use shr_nuopc_fldList_mod , only : nmappers
 
@@ -64,7 +65,7 @@ module med_internalstate_mod
     logical               :: FBExpAccumFlag(ncomps) = .false.   ! Accumulator flag, if true accumulation was done
     integer               :: conn_prep_cnt(ncomps)              ! Connector prep count
     integer               :: conn_post_cnt(ncomps)              ! Connector post count
-    integer               :: mpicom
+    type(ESMF_VM)         :: vm
 
     ! CESM-specific internal state fields
     type(ESMF_FieldBundle):: FBMed_ocnalb_o                     ! Ocn albedo on ocn grid

--- a/src/drivers/nuopc/mediator/med_phases_history_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_history_mod.F90
@@ -73,7 +73,6 @@ contains
     type(InternalState)     :: is_local
     character(CS)           :: histavg_option ! Histavg option units
     integer                 :: i,j,m,n,n1,ncnt
-    integer                 :: mpicom, iam
     integer                 :: start_ymd      ! Starting date YYYYMMDD
     integer                 :: start_tod      ! Starting time-of-day (s)
     integer                 :: nx,ny          ! global grid size
@@ -93,6 +92,7 @@ contains
     real(r8)                :: tbnds(2)       ! CF1.0 time bounds
     logical                 :: whead,wdata    ! for writing restart/history cdf files
     integer                 :: dbrc
+    integer                 :: iam
     logical,save            :: first_call = .true.
     character(len=*), parameter :: subname='(med_phases_history_write)'
     logical :: isPresent
@@ -111,7 +111,7 @@ contains
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, mpiCommunicator=mpicom, localPet=iam, rc=rc)
+    call ESMF_VMGet(vm, localPet=iam, rc=rc)
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !---------------------------------------
@@ -249,7 +249,7 @@ contains
        write(hist_file,"(6a)") &
             trim(case_name), '.cpl',trim(cpl_inst_tag),'.hi.', trim(nexttimestr),'.nc'
        call ESMF_LogWrite(trim(subname)//": write "//trim(hist_file), ESMF_LOGMSG_INFO, rc=dbrc)
-       call med_io_wopen(hist_file, mpicom, iam, clobber=.true.)
+       call med_io_wopen(hist_file, vm, iam, clobber=.true.)
 
        do m = 1,2
           whead=.false.

--- a/src/drivers/nuopc/mediator/med_phases_ocnalb_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_ocnalb_mod.F90
@@ -55,7 +55,7 @@ contains
     use ESMF                  , only : operator(==)
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_getFieldN
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use shr_nuopc_utils_mod , only : shr_nuopc_utils_chkerr
     use med_internalstate_mod , only : InternalState
     use med_constants_mod     , only : CL, R8
     use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
@@ -91,15 +91,15 @@ contains
 
     ! The following is for debugging
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_VMGet(vm, localPet=iam, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Get the internal state from gcomp
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     !----------------------------------
     ! Set pointers to fields needed for albedo calculations
@@ -109,13 +109,13 @@ contains
     ! The following sets pointers to the module arrays
 
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdr', fldptr1=ocnalb%avsdr, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdf', fldptr1=ocnalb%avsdf, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidr', fldptr1=ocnalb%anidr, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidf', fldptr1=ocnalb%anidf, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     !----------------------------------
     ! Get lat, lon, which are time-invariant
@@ -124,18 +124,18 @@ contains
     ! The following assumes that all fields in FBMed_ocnalb_o have the same grid - so
     ! only need to query field 1
     call shr_nuopc_methods_FB_getFieldN(is_local%wrap%FBMed_ocnalb_o, fieldnum=1, field=lfield, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Determine if first field is on a grid or a mesh - default will be mesh
     call ESMF_FieldGet(lfield, geomtype=geomtype, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (geomtype == ESMF_GEOMTYPE_MESH) then
        call ESMF_LogWrite(trim(subname)//" : FBAtm is on a mesh ", ESMF_LOGMSG_INFO, rc=rc)
        call ESMF_FieldGet(lfield, mesh=lmesh, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_MeshGet(lmesh, spatialDim=spatialDim, numOwnedElements=numOwnedElements, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        lsize = size(ocnalb%anidr)
        if (numOwnedElements /= lsize) then
           write(tempc1,'(i10)') numOwnedElements
@@ -149,7 +149,7 @@ contains
        allocate(ocnalb%lons(numOwnedElements))
        allocate(ocnalb%lats(numOwnedElements))
        call ESMF_MeshGet(lmesh, ownedElemCoords=ownedElemCoords)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        do n = 1,lsize
           ocnalb%lons(n) = ownedElemCoords(2*n-1)
           ocnalb%lats(n) = ownedElemCoords(2*n)
@@ -189,7 +189,7 @@ contains
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_diagnose
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_State_GetScalar
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_FieldRegrid
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use shr_nuopc_utils_mod , only : shr_nuopc_utils_chkerr
     use med_constants_mod     , only : CS, CL, R8
     use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
     use med_internalstate_mod , only : InternalState, logunit
@@ -247,7 +247,7 @@ contains
     ! Get the internal state from Component.
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Note that in the mct version the atm was initialized first so
     ! that nextsw_cday could be passed to the other components - this
@@ -259,10 +259,10 @@ contains
 
        ! Initialize ocean albedo calculation
        call med_phases_ocnalb_init(gcomp, ocnalb, rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
        call NUOPC_CompAttributeGet(gcomp, name='start_type', value=cvalue, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) starttype
 
        if (trim(starttype) == trim('startup')) then
@@ -276,47 +276,47 @@ contains
        end if
 
        call ESMF_GridCompGet(gcomp, clock=clock)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
        if (trim(runtype) == 'initial') then
           call ESMF_TimeGet( currTime, dayOfYear_r8=nextsw_cday, rc=rc )
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        else
           call shr_nuopc_methods_State_GetScalar(is_local%wrap%NstateImp(compatm), &
                flds_scalar_name=flds_scalar_name, flds_scalar_num=flds_scalar_num, &
-               scalar_id=flds_scalar_index_nextsw_cday, value=nextsw_cday, mpicom=is_local%wrap%mpicom, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+               scalar_id=flds_scalar_index_nextsw_cday, value=nextsw_cday, rc=rc)
+          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        end if
 
        first_call = .false.
 
     else
 
-       ! Note that shr_nuopc_methods_State_GetScalar includes a broadcast to all other pets im mpicom
+       ! Note that shr_nuopc_methods_State_GetScalar includes a broadcast to all other pets
        call shr_nuopc_methods_State_GetScalar(is_local%wrap%NstateImp(compatm), &
             flds_scalar_name=flds_scalar_name, flds_scalar_num=flds_scalar_num, &
-            scalar_id=flds_scalar_index_nextsw_cday, value=nextsw_cday, mpicom=is_local%wrap%mpicom, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+            scalar_id=flds_scalar_index_nextsw_cday, value=nextsw_cday, rc=rc)
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     end if
 
     call NUOPC_CompAttributeGet(gcomp, name='flux_albav', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) flux_albav
 
     call NUOPC_CompAttributeGet(gcomp, name='orb_eccen', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) eccen
     call NUOPC_CompAttributeGet(gcomp, name='orb_obliqr', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) obliqr
     call NUOPC_CompAttributeGet(gcomp, name='orb_lambm0', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) lambm0
     call NUOPC_CompAttributeGet(gcomp, name='orb_mvelpp', value=cvalue, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) mvelpp
 
     ! Calculate ocean albedos on the ocean grid
@@ -366,20 +366,20 @@ contains
     ! Update current ifrad/ofrad values if albedo was updated in field bundle
     if (update_alb) then
        call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ifrac', fldptr1=ifrac, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ifrad', fldptr1=ifrad, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ofrac', fldptr1=ofrac, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ofrad', fldptr1=ofrad, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        ifrad(:) = ifrac(:)
        ofrad(:) = ofrac(:)
     endif
 
     if (dbug_flag > 1) then
        call shr_nuopc_methods_FB_diagnose(is_local%wrap%FBMed_ocnalb_o, string=trim(subname)//' FBMed_ocnalb_o', rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     end if
     call t_stopf('MED:'//subname)
 
@@ -395,7 +395,7 @@ contains
 
     use ESMF                  , only : ESMF_GridComp
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
+    use shr_nuopc_utils_mod , only : shr_nuopc_utils_chkerr
     use med_map_mod           , only : med_map_FB_Regrid_Norm
     use med_internalstate_mod , only : InternalState
     use med_constants_mod     , only : R8
@@ -422,7 +422,7 @@ contains
     ! Get the internal state from gcomp
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Map the field bundle from the ocean to the atm grid
     call med_map_FB_Regrid_Norm( &
@@ -433,7 +433,7 @@ contains
          is_local%wrap%FBNormOne(compocn,compatm,:), &
          is_local%wrap%RH(compocn,compatm,:), &
          string='FBMed_ocnalb_o_To_FBMed_ocnalb_a', rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_ocnalb_mapo2a

--- a/src/drivers/nuopc/mediator/med_phases_profile_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_profile_mod.F90
@@ -121,10 +121,6 @@ contains
           call ESMF_ClockGetNextTime(clock, nextTime=nexttime, rc=rc)
           if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          prevtime = nexttime
-          call ESMF_TimeGet(nexttime, timestring=nexttimestr, rc=rc)
-          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
-
           call ESMF_VMWtime(current_time, rc=rc)
           if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -150,6 +146,9 @@ contains
              if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
              avgdt = wallclockelapsed/ringdays
           endif
+          prevtime = nexttime
+          call ESMF_TimeGet(nexttime, timestring=nexttimestr, rc=rc)
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
           ! get current wall clock time
           call ESMF_TimeSet(wallclocktime, rc=rc)
           if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return

--- a/src/drivers/nuopc/shr/shr_nuopc_grid_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_grid_mod.F90
@@ -1,361 +1,20 @@
 !================================================================================
 module shr_nuopc_grid_mod
-
+    use shr_nuopc_utils_mod, only : shr_nuopc_utils_ChkErr
   implicit none
   private
 
-  public :: shr_nuopc_grid_ArbInit
-  public :: shr_nuopc_grid_DEInit
-  public :: shr_nuopc_grid_RegInit
   public :: shr_nuopc_grid_MeshInit
   public :: shr_nuopc_grid_ArrayToState
   public :: shr_nuopc_grid_StateToArray
-  public :: shr_nuopc_grid_CreateCoords
-  public :: shr_nuopc_grid_CopyCoord
-  public :: shr_nuopc_grid_CopyItem
 
- !integer             :: dbug_flag = 6
-  integer             :: dbug_flag = 0
-  character(len=1024) :: tmpstr
-  character(len=1024) :: msgString
   character(len=*), parameter :: u_FILE_u = &
     __FILE__
 
 !-----------------------------------------------------------------------------
 contains
 !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_ArbInit(nx_global, ny_global, mpicom, gindex, EGrid, rc)
-
-    !-----------------------------------------
-    ! create a Egrid object for Fields
-    !-----------------------------------------
-    use ESMF, only : ESMF_Grid, ESMF_SUCCESS, ESMF_LOGERR_PASSTHRU
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_GridAddItem
-    use ESMF, only : ESMF_GridCreate1PeriDim, ESMF_GridAddCoord, ESMF_LogFoundError
-    use ESMF, only : ESMF_GRIDITEM_AREA, ESMF_GRIDITEM_MASK, ESMF_COORDSYS_SPH_DEG
-    use ESMF, only : ESMF_STAGGERLOC_CENTER, ESMF_GridCreate1PeriDim
-    use ESMF, only : ESMF_TYPEKIND_R8, ESMF_TYPEKIND_I4
-    use mpi, only : mpi_comm_rank
-    integer         , intent(in)    :: nx_global
-    integer         , intent(in)    :: ny_global
-    integer         , intent(in)    :: mpicom
-    integer         , intent(in)    :: gindex(:)
-    type(ESMF_Grid) , intent(inout) :: Egrid
-    integer         , intent(inout) :: rc
-
-    !--- local ---
-    integer          :: n
-    integer          :: iam,ierr
-    integer          :: lsize
-    integer, pointer :: localArbIndex(:,:)
-    integer :: dbrc
-    character(len=*),parameter :: subname='(shr_nuopc_grid_ArbInit)'
-    !--------------------------------------------------------------
-
-    rc = ESMF_SUCCESS
-
-    call MPI_COMM_RANK(mpicom, iam, ierr)
-    call ESMF_LogWrite(subname, ESMF_LOGMSG_INFO, rc=dbrc)
-
-    lsize = size(gindex)
-    allocate(localArbIndex(lsize,2))
-    do n = 1,lsize
-       localArbIndex(n,1) = mod(gindex(n)-1,nx_global) + 1
-       localArbIndex(n,2) = (gindex(n)-1)/nx_global + 1
-    enddo
-
-    Egrid=ESMF_GridCreate1PeriDim(&
-         minIndex = (/1,1/), &
-         maxIndex = (/nx_global,ny_global/), &
-         arbIndexCount = lsize, &
-         arbIndexList = localArbIndex, &
-         periodicDim = 1, &
-         coordSys = ESMF_COORDSYS_SPH_DEG, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    deallocate(localArbIndex)
-
-    call ESMF_GridAddCoord(Egrid, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    ! call ESMF_GridAddCoord(Egrid, staggerLoc=ESMF_STAGGERLOC_CORNER, rc=rc)
-    ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    call ESMF_GridAddItem(Egrid, itemFlag=ESMF_GRIDITEM_MASK, itemTypeKind=ESMF_TYPEKIND_I4, &
-         staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    call ESMF_GridAddItem(Egrid, itemFlag=ESMF_GRIDITEM_AREA, itemTypeKind=ESMF_TYPEKIND_R8, &
-         staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-  end subroutine shr_nuopc_grid_ArbInit
-
-  !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_DEInit(gcomp, nx_global, ny_global, mpicom, gindex, Egrid, rc)
-
-    !-----------------------------------------
-    ! create a Egrid object for Fields
-    !-----------------------------------------
-    use shr_kind_mod, only : R8=>shr_kind_r8
-    use ESMF, only : ESMF_GridComp, ESMF_Grid, ESMF_GridCompGet, ESMF_VM, ESMF_VMGet
-    use ESMF, only : ESMF_GridGetCoord, ESMF_GRIDITEM_MASK, ESMF_GridGet, ESMF_GridGetItem
-    use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_LogWrite
-    use ESMF, only : ESMF_VMAllReduce, ESMF_DistGridConnectionSet, ESMF_DistGrid, ESMF_DELayout
-    use ESMF, only : ESMF_DistGridGet, ESMF_DistGridPrint, ESMF_GridAddCoord, ESMF_GridAddItem
-    use ESMF, only : ESMF_GRIDITEM_AREA, ESMF_TYPEKIND_R8, ESMF_TYPEKIND_I4
-    use ESMF, only : ESMF_STAGGERLOC_CENTER, ESMF_DELayoutCreate, ESMF_VMAllReduce
-    use ESMF, only : ESMF_REDUCE_SUM, ESMF_LOGMSG_INFO, ESMF_DistGridConnection, ESMF_Grid
-    use ESMF, only : ESMF_GridCreate, ESMF_COORDSYS_SPH_DEG
-    use ESMF, only : ESMF_DistGridCreate
-    use mpi, only : mpi_comm_rank
-    use shr_sys_mod, only : shr_sys_abort
-
-    type(ESMF_GridComp)             :: gcomp
-    integer         , intent(in)    :: nx_global
-    integer         , intent(in)    :: ny_global
-    integer         , intent(in)    :: mpicom
-    integer         , intent(in)    :: gindex(:)
-    type(ESMF_Grid) , intent(inout) :: Egrid
-    integer         , intent(inout) :: rc
-
-    !--- local ---
-    integer             :: n,n1,n2,ig,jg,cnt
-    integer             :: de,decount,dimcount
-    integer             :: iam,ierr
-    integer             :: lsize,gsize,nblocks_tot,ngseg
-    integer             :: lbnd(2),ubnd(2)
-    integer             :: global_index
-    integer, pointer    :: indexList(:)
-    integer, pointer    :: deBlockList(:,:,:)
-    integer, pointer    :: petMap(:)
-    real(r8),pointer    :: falon(:),falat(:)
-    real(r8),pointer    :: famask(:),faarea(:)
-    integer, pointer    :: iarray2(:,:)
-    real(r8),pointer    :: farray2(:,:)
-    type(ESMF_DELayout) :: delayout
-    type(ESMF_DistGrid) :: distgrid
-    integer ,pointer    :: pes_local(:)
-    integer ,pointer    :: pes_global(:)
-    type(ESMF_VM)       :: vm
-    integer             :: petCount
-    type(ESMF_DistGridConnection), allocatable :: connectionList(:)
-    integer :: dbrc
-    character(len=*),parameter :: subname='(shr_nuopc_grid_DEInit)'
-    !--------------------------------------------------------------
-
-    call MPI_COMM_RANK(mpicom, iam, ierr)
-
-    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u))  return  ! bail out
-
-    call ESMF_VMGet(vm, petCount=petCount, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return  ! bail out
-
-    ! 1 gridcell per DE
-
-    lsize = size(gindex)
-    gsize = nx_global * ny_global
-
-    write(tmpstr,'(a,4i8)') subname//' nx,ny,lsize = ',nx_global,ny_global,lsize,gsize
-    call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-
-    nblocks_tot = gsize
-
-    allocate(deBlockList(2,2,nblocks_tot))
-    allocate(petMap(nblocks_tot))
-
-    write(tmpstr,'(a,1i8)') subname//' nblocks = ',nblocks_tot
-    call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-
-    allocate(pes_local(gsize))
-    allocate(pes_global(gsize))
-
-    pes_local(:) = 0
-    do n = 1,lsize
-       pes_local(gindex(n)) = iam
-    end do
-
-    call ESMF_VMAllReduce(vm, sendData=pes_local, recvData=pes_global, count=nx_global*ny_global, &
-         reduceflag=ESMF_REDUCE_SUM, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u))  return  ! bail out
-
-    ! Note that below this is a global search overall all the points - not just the ones
-    ! passed in my gindex(:)
-    n = 0
-    do global_index = 1,gsize
-       ig = mod(global_index-1,nx_global) + 1
-       jg = (global_index-1)/nx_global + 1
-       deBlockList(1,1,n) = ig
-       deBlockList(1,2,n) = ig
-       deBlockList(2,1,n) = jg
-       deBlockList(2,2,n) = jg
-       petMap(global_index) = pes_global(global_index)
-       ! write(tmpstr,'(a,2i8)') subname//' IDs  = ',n,petMap(n)
-       ! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-       ! write(tmpstr,'(a,3i8)') subname//' iglo = ',n,deBlockList(1,1,n),deBlockList(1,2,n)
-       ! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-       ! write(tmpstr,'(a,3i8)') subname//' jglo = ',n,deBlockList(2,1,n),deBlockList(2,2,n)
-       ! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-    enddo
-
-    deallocate(pes_local)
-    deallocate(pes_global)
-
-    delayout = ESMF_DELayoutCreate(petMap, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    allocate(connectionList(1))
-    call ESMF_DistGridConnectionSet(connectionList(1), tileIndexA=1, &
-         tileIndexB=1, positionVector=(/nx_global, 0/), rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=u_FILE_u)) &
-         return  ! bail out
-
-    distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/nx_global,ny_global/), &
-         !          indexflag = ESMF_INDEX_DELOCAL, &
-         deBlockList=deBlockList, &
-         delayout=delayout, &
-         connectionList=connectionList, &
-         rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    deallocate(deBlockList)
-    deallocate(petMap)
-    deallocate(connectionList)
-
-    call ESMF_DistGridPrint(distgrid=distgrid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=u_FILE_u)) &
-         return  ! bail out
-
-    call ESMF_DistGridGet(distgrid=distgrid, localDE=0, elementCount=cnt, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-    allocate(indexList(cnt))
-    !      write(tmpstr,'(a,i8)') subname//' distgrid cnt= ',cnt
-    !      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-    call ESMF_DistGridGet(distgrid=distgrid, localDE=0, seqIndexList=indexList, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-    !      write(tmpstr,'(a,4i8)') subname//' distgrid list= ',indexList(1),indexList(cnt),minval(indexList), maxval(indexList)
-    !      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-    deallocate(IndexList)
-
-    Egrid = ESMF_GridCreate(distgrid=distgrid, &
-         coordSys = ESMF_COORDSYS_SPH_DEG, &
-         gridEdgeLWidth=(/0,0/), gridEdgeUWidth=(/0,1/), &
-         rc = rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    call ESMF_GridGet(Egrid, localDEcount=DEcount, dimCount=dimCount, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    !      write(tmpstr,'(a,2i8)') subname//' localDEcount = ',DEcount,lsize
-    !      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-    !      write(tmpstr,'(a,2i8)') subname//' dimCount = ',dimCount
-    !      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-
-    if (DEcount /= lsize) then
-       call shr_sys_abort(subname//' DEcount /= lsize')
-    endif
-
-    call ESMF_GridAddCoord(Egrid, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-    !      call ESMF_GridAddCoord(Egrid, staggerLoc=ESMF_STAGGERLOC_CORNER, rc=rc)
-    !      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-    call ESMF_GridAddItem(Egrid, itemFlag=ESMF_GRIDITEM_MASK, itemTypeKind=ESMF_TYPEKIND_I4, &
-         staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-    call ESMF_GridAddItem(Egrid, itemFlag=ESMF_GRIDITEM_AREA, itemTypeKind=ESMF_TYPEKIND_R8, &
-         staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-    allocate(falon(lsize),falat(lsize),famask(lsize),faarea(lsize))
-
-    do n = 1,lsize
-       DE = n-1
-
-       !         write(tmpstr,'(a,3i8)') subname//' n,DE,lsize ',n,DE,lsize
-       !         call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-       !         write(tmpstr,'(a,i8,4g13.6)') subname//' grid values ',DE,falon(n),falat(n),famask(n),faarea(n)
-       !         call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-
-       call ESMF_GridGetCoord(Egrid, coordDim=1, localDE=DE, staggerLoc=ESMF_STAGGERLOC_CENTER, &
-            computationalLBound=lbnd, computationalUBound=ubnd, &
-            farrayPtr=farray2, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-       farray2(1,1) = falon(n)
-
-       !         write(tmpstr,'(a,5i8)') subname//' lbnd ubnd ',DE,lbnd,ubnd
-       !         call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=dbrc)
-
-       call ESMF_GridGetCoord(Egrid, coordDim=2, localDE=DE, staggerLoc=ESMF_STAGGERLOC_CENTER, &
-            farrayPtr=farray2, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-       farray2(1,1) = falat(n)
-
-       call ESMF_GridGetItem(Egrid, itemflag=ESMF_GRIDITEM_MASK, localDE=DE, staggerloc=ESMF_STAGGERLOC_CENTER, &
-            farrayPtr=iarray2, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-       iarray2(1,1) = nint(famask(n))
-
-       call ESMF_GridGetItem(Egrid, itemflag=ESMF_GRIDITEM_AREA, localDE=DE, staggerloc=ESMF_STAGGERLOC_CENTER, &
-            farrayPtr=farray2, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-       farray2(1,1) = faarea(n)
-
-    enddo
-    deallocate(falon,falat,famask,faarea)
-
-  end subroutine shr_nuopc_grid_DEInit
-
-  !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_RegInit(nx_global, ny_global, mpicom, EGrid, rc)
-
-    !-----------------------------------------
-    ! create a Grid object for Fields
-    !-----------------------------------------
-    use shr_kind_mod, only : R8=>shr_kind_r8
-    use mpi, only : mpi_comm_rank
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
-    use ESMF, only : ESMF_GridCreateNoPeriDimUfrm, ESMF_COORDSYS_SPH_DEG, ESMF_STAGGERLOC_CENTER
-    use ESMF, only : ESMF_Grid, ESMF_SUCCESS
-    integer         , intent(in)    :: nx_global
-    integer         , intent(in)    :: ny_global
-    integer         , intent(in)    :: mpicom
-    type(ESMF_Grid) ,intent(inout)  :: Egrid
-    integer         , intent(inout) :: rc
-
-    !--- local ---
-    integer :: iam,ierr
-    integer :: dbrc
-    character(len=*),parameter :: subname='(shr_nuopc_grid_RegInit)'
-    !--------------------------------------------------------------
-
-    rc = ESMF_SUCCESS
-
-    call MPI_COMM_RANK(mpicom, iam, ierr)
-    call ESMF_LogWrite(subname, ESMF_LOGMSG_INFO, rc=dbrc)
-
-    Egrid = ESMF_GridCreateNoPeriDimUfrm(maxIndex=(/nx_global, ny_global/), &
-         minCornerCoord=(/0._R8, -180._R8/), &
-         maxCornerCoord=(/360._R8, 180._R8/), &
-         coordSys=ESMF_COORDSYS_SPH_DEG, staggerLocList=(/ESMF_STAGGERLOC_CENTER/), &
-         rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=u_FILE_u)) &
-         return  ! bail out
-
-  end subroutine shr_nuopc_grid_RegInit
-
-  !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_MeshInit(gcomp, nx_global, ny_global, mpicom, gindex, lon, lat, Emesh, rc)
+  subroutine shr_nuopc_grid_MeshInit(gcomp, nx_global, ny_global, gindex, lon, lat, Emesh, rc)
 
     !-----------------------------------------
     ! create an Emesh object for Fields
@@ -367,12 +26,10 @@ contains
     use ESMF, only : ESMF_VMGather, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
     use ESMF, only : ESMF_MeshCreate, ESMF_COORDSYS_SPH_DEG, ESMF_REDUCE_SUM
     use ESMF, only : ESMF_VMAllReduce, ESMF_MESHELEMTYPE_QUAD
-    use mpi, only : mpi_comm_rank
 
     type(ESMF_GridComp)               :: gcomp
     integer           , intent(in)    :: nx_global
     integer           , intent(in)    :: ny_global
-    integer           , intent(in)    :: mpicom
     integer           , intent(in)    :: gindex(:)
     real(r8), pointer , intent(in)    :: lon(:)
     real(r8), pointer , intent(in)    :: lat(:)
@@ -381,7 +38,7 @@ contains
 
     !--- local ---
     integer          :: n,n1,n2,de
-    integer          :: iam,ierr
+    integer          :: iam
     integer          :: lsize
     integer          :: numTotElems, numNodes, numConn, nodeindx
     integer          :: iur,iul,ill,ilr
@@ -404,22 +61,21 @@ contains
     integer          :: sendData(1)
     type(ESMF_VM)    :: vm
     integer          :: petCount
-    integer :: dbrc
     character(len=*),parameter :: subname='(shr_nuopc_grid_MeshInit)'
     !--------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
-    call MPI_COMM_RANK(mpicom, iam, ierr)
-    call ESMF_LogWrite(subname, ESMF_LOGMSG_INFO, rc=dbrc)
+    call ESMF_LogWrite(subname, ESMF_LOGMSG_INFO, rc=rc)
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     lsize = size(gindex)
 
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u))  return  ! bail out
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_VMGet(vm, petCount=petCount, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return  ! bail out
+    call ESMF_VMGet(vm, petCount=petCount, localpet=iam, rc=rc)
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     allocate(latG(nx_global*ny_global))
     allocate(lonG(nx_global*ny_global))
@@ -429,10 +85,10 @@ contains
 
     sendData(1) = lsize
     call ESMF_VMGather(vm, sendData=sendData, recvData=recvCounts, count=1, rootPet=0, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return  ! bail out
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_VMBroadCast(vm, bcstData=recvCounts, count=petCount, rootPet=0, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return  ! bail out
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     recvoffsets(1) = 0
     do n = 2,petCount
@@ -440,10 +96,10 @@ contains
     end do
 
     call ESMF_VMAllGatherV(vm, lat, lsize, latG, recvCounts, recvOffsets, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u))  return  ! bail out
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_VMAllGatherV(vm, lon, lsize, lonG, recvCounts, recvOffsets, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u))  return  ! bail out
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(recvoffsets)
     deallocate(recvCounts)
@@ -560,7 +216,7 @@ contains
 
     call ESMF_VMAllReduce(vm, sendData=pes_local, recvData=pes_global, count=nx_global*ny_global, &
          reduceflag=ESMF_REDUCE_SUM, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u))  return  ! bail out
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1,numNodes
        nodeOwners(n) = pes_global(iurpts(n))
@@ -610,7 +266,7 @@ contains
     use shr_kind_mod          , only : R8=>shr_kind_r8, CS=>shr_kind_cs, IN=>shr_kind_in
     use shr_string_mod        , only : shr_string_listGetName, shr_string_listGetNum
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_State_reset
-
+    use med_constants_mod, only : CL
     !----- arguments -----
     real(r8)         , intent(inout) :: array(:,:)
     character(len=*) , intent(in)    :: rList
@@ -624,6 +280,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(R8), pointer :: farray1(:)
     integer           :: dbrc
+    character(len=CL) :: tmpstr
     character(*),parameter :: subName = "(shr_nuopc_grid_ArrayToState)"
     !----------------------------------------------------------
 
@@ -663,6 +320,7 @@ contains
     use ESMF           , only : ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS, ESMF_LOGMSG_INFO
     use shr_kind_mod   , only : R8=>shr_kind_r8, CS=>shr_kind_CS, IN=>shr_kind_in
     use shr_string_mod , only : shr_string_listGetName, shr_string_listGetNum
+    use med_constants_mod, only : CL
 
     !----- arguments -----
     type(ESMF_State) , intent(in)    :: state
@@ -677,6 +335,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(R8), pointer :: farray1(:)
     integer           :: dbrc
+    character(len=CL) :: tmpstr
     character(*),parameter :: subName = "(shr_nuopc_grid_StateToArray)"
     !----------------------------------------------------------
 
@@ -708,513 +367,5 @@ contains
     enddo
 
   end subroutine shr_nuopc_grid_StateToArray
-
-  !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_CreateCoords(gridNew, gridOld, rc)
-    use ESMF                  , only : ESMF_Grid, ESMF_DistGrid, ESMF_CoordSys_Flag, ESMF_Index_Flag
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_GridGet, ESMF_GridAddCoord
-    use ESMF                  , only : ESMF_GridGetCoord, ESMF_GridAddCoord, ESMF_STAGGERLOC_CENTER
-    use ESMF                  , only : ESMF_GridCreate, ESMF_SUCCESS, ESMF_STAGGERLOC_CORNER
-    use shr_kind_mod          , only : R8=>shr_kind_r8
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_ChkErr
-
-    type(ESMF_Grid), intent(inout) :: gridNew
-    type(ESMF_Grid), intent(inout) :: gridOld
-    integer        , intent(out)   :: rc
-
-    ! local variables
-    integer                    :: localDE, localDECount
-    type(ESMF_DistGrid)        :: distgrid
-    type(ESMF_CoordSys_Flag)   :: coordSys
-    type(ESMF_Index_Flag)      :: indexflag
-    real(R8),pointer           :: dataPtr1(:,:), dataPtr2(:,:)
-    integer                    :: dimCount
-    integer, pointer           :: gridEdgeLWidth(:), gridEdgeUWidth(:)
-    character(len=*),parameter :: subname='(shr_nuopc_methods_grid_createcoords)'
-    integer :: dbrc
-    ! ----------------------------------------------
-
-    if (dbug_flag > 10) then
-      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-    rc = ESMF_SUCCESS
-
-    call ESMF_LogWrite(trim(subname)//": tcxA", ESMF_LOGMSG_INFO, rc=dbrc)
-
-    call ESMF_GridGet(gridold, dimCount=dimCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    allocate(gridEdgeLWidth(dimCount),gridEdgeUWidth(dimCount))
-    call ESMF_GridGet(gridold,distgrid=distgrid, coordSys=coordSys, indexflag=indexflag, dimCount=dimCount, &
-       gridEdgeLWidth=gridEdgeLWidth, gridEdgeUWidth=gridEdgeUWidth, localDECount=localDECount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_LogWrite(trim(subname)//": tcxB", ESMF_LOGMSG_INFO, rc=dbrc)
-
-    write(msgString,*) trim(subname)//' localDECount = ',localDECount
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
-    write(msgString,*) trim(subname)//' dimCount = ',dimCount
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
-    write(msgString,*) trim(subname)//' size(gELW) = ',size(gridEdgeLWidth)
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
-    write(msgString,*) trim(subname)//' gridEdgeLWidth = ',gridEdgeLWidth
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
-    write(msgString,*) trim(subname)//' gridEdgeUWidth = ',gridEdgeUWidth
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
-
-    call ESMF_LogWrite(trim(subname)//": tcxC", ESMF_LOGMSG_INFO, rc=dbrc)
-
-    gridnew = ESMF_GridCreate(distgrid=distgrid, coordSys=coordSys, indexflag=indexflag, &
-       gridEdgeLWidth=gridEdgeLWidth, gridEdgeUWidth=gridEdgeUWidth, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    deallocate(gridEdgeLWidth, gridEdgeUWidth)
-
-    call ESMF_GridAddCoord(gridnew, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_GridAddCoord(gridnew, staggerLoc=ESMF_STAGGERLOC_CORNER, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    do localDE = 0,localDeCount-1
-
-      call ESMF_GridGetCoord(gridold, coordDim=1, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CENTER, farrayPtr=dataPtr1, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_GridGetCoord(gridnew, coordDim=1, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CENTER, farrayPtr=dataPtr2, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      dataPtr2 = dataPtr1
-
-      call ESMF_GridGetCoord(gridold, coordDim=2, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CENTER, farrayPtr=dataPtr1, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_GridGetCoord(gridnew, coordDim=2, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CENTER, farrayPtr=dataPtr2, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      dataPtr2 = dataPtr1
-
-      call ESMF_GridGetCoord(gridold, coordDim=1, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CORNER, farrayPtr=dataPtr1, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_GridGetCoord(gridnew, coordDim=1, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CORNER, farrayPtr=dataPtr2, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      dataPtr2 = dataPtr1
-
-      call ESMF_GridGetCoord(gridold, coordDim=2, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CORNER, farrayPtr=dataPtr1, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_GridGetCoord(gridnew, coordDim=2, localDE=localDE,  &
-        staggerLoc=ESMF_STAGGERLOC_CORNER, farrayPtr=dataPtr2, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      dataPtr2 = dataPtr1
-
-    enddo
-
-    if (dbug_flag > 10) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-
-  end subroutine shr_nuopc_grid_CreateCoords
-
-  !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_CopyCoord(gridcomp, gridSrc, gridDst, staggerloc, &
-       tolerance, compare, invert, rc)
-    use shr_kind_mod, only : I8=>shr_kind_i8, I4=> shr_kind_in
-    use ESMF, only : ESMF_GridComp, ESMF_Grid, ESMF_StaggerLoc, ESMF_VM, ESMF_DistGrid, ESMF_Array
-    use ESMF, only : ESMF_TypeKind_Flag, ESMF_CoordSys_Flag, ESMF_RouteHandle
-    use ESMF, only : ESMF_GridGet, ESMF_LogSetError, ESMF_VMGet, ESMF_GridAddCoord, ESMF_GridGetCoord
-    use ESMF, only : ESMF_RC_ARG_BAD, ESMF_ArrayGet, ESMF_DistGridGet
-    use ESMF, only : ESMF_LogWrite, ESMF_SUCCESS, ESMF_LOGMSG_INFO
-    use ESMF, only : ESMF_ArraySMMStore, ESMF_GridCompGet
-    use ESMF, only : ESMF_ArraySMM, ESMF_ArraySMMRelease
-    use ESMF, only : ESMF_ArrayRedist, ESMF_ArrayRedistStore, ESMF_ArrayRedistRelease
-    use ESMF, only : ESMF_RC_NOT_IMPL, ESMF_LogSetError
-    use ESMF, only : operator(/=)
-    use shr_nuopc_methods_mod, only : shr_nuopc_methods_Distgrid_Match, shr_nuopc_methods_ChkErr
-
-    ! Arguments
-    type(ESMF_GridComp) ,  intent(in)           :: gridcomp
-    type(ESMF_Grid),       intent(in)           :: gridSrc
-    type(ESMF_Grid),       intent(in)           :: gridDst
-    type(ESMF_StaggerLoc), intent(in)           :: staggerloc(:)
-    real,                  intent(in), optional :: tolerance
-    logical,               intent(in), optional :: compare
-    integer,               intent(in), optional :: invert(:)
-    integer,               intent(out),optional :: rc
-
-    ! Local Variables
-    real                              :: l_tolerance
-    logical                           :: l_compare
-    integer, allocatable              :: l_invert(:)
-    integer                           :: i
-    type(ESMF_VM)                     :: vm
-    type(ESMF_DistGrid)               :: distGridSrc, distGridDst
-    type(ESMF_Array)                  :: coordArraySrc, coordArrayDst
-    integer(I4),allocatable :: factorList(:)
-    integer, allocatable              :: factorIndexList(:,:)
-    type(ESMF_RouteHandle)            :: routehandle
-    integer                           :: dimCountSrc, dimCountDst
-    integer                           :: deCountDst
-    integer, allocatable              :: elementCountPDeDst(:)
-    integer(I8)             :: sumElementCountPDeDst
-    type(ESMF_TypeKind_Flag)          :: coordTypeKindSrc, coordTypeKindDst
-    type(ESMF_CoordSys_Flag)          :: coordSysSrc, coordSysDst
-    logical                           :: isPresentSrc, isPresentDst
-    integer                           :: dimIndex, staggerlocIndex
-    integer                           :: localPet
-    character(len=10)                 :: numString
-    integer :: dbrc
-    character(len=*), parameter       :: subname='(shr_nuopc_methods_Grid_CopyCoord)'
-    ! ----------------------------------------------
-
-    if (dbug_flag > 10) then
-      call ESMF_LogWrite(subname//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-
-    l_tolerance = 0.0
-    if (present(tolerance)) l_tolerance = tolerance
-    l_compare = .FALSE.
-    if (present(compare)) l_compare = compare
-    if (present(invert)) then
-      allocate(l_invert(size(invert)))
-      l_invert = invert
-    else
-      allocate(l_invert(1))
-      l_invert = -1
-    endif
-
-    call ESMF_GridGet(gridSrc, distGrid=distGridSrc, &
-      dimCount=dimCountSrc, coordTypeKind=coordTypeKindSrc, &
-      coordSys=coordSysSrc, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_GridGet(gridDst, distGrid=distGridDst, &
-      dimCount=dimCountDst, coordTypeKind=coordTypeKindDst, &
-      coordSys=coordSysDst, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (.NOT. shr_nuopc_methods_Distgrid_Match(distGrid1=distGridSrc, distGrid2=distGridDst, rc=rc)) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": Unable to redistribute coordinates. DistGrids do not match.", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    if ( dimCountSrc /= dimCountDst) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": DIMCOUNT MISMATCH", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    if ( coordTypeKindSrc /= coordTypeKindDst) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": COORDTYPEKIND MISMATCH", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    if ( coordSysSrc /= coordSysDst) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": COORDSYS MISMATCH", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    do dimIndex=1, dimCountDst
-    do staggerlocIndex=1, size(staggerloc)
-      call ESMF_GridGetCoord(gridSrc, staggerloc=staggerloc(staggerlocIndex), &
-        isPresent=isPresentSrc, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      if(isPresentSrc) then
-        call ESMF_GridGetCoord(gridSrc, coordDim=dimIndex, &
-          staggerloc=staggerloc(staggerlocIndex), &
-          array=coordArraySrc, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_GridGetCoord(gridDst, &
-          staggerloc=staggerloc(staggerlocIndex), &
-          isPresent=isPresentDst, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        if(.NOT.isPresentDst) then
-          call ESMF_GridAddCoord(gridDst, &
-            staggerLoc=staggerloc(staggerlocIndex), rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        else
-          if(l_compare .EQV. .TRUE.) then
-            ! TODO: Compare existing coordinates
-            call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
-              msg=subname//": Cannot compare existing coordinates.", &
-              line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-              return  ! bail out
-          end if
-        endif
-        call ESMF_GridGetCoord(gridDst, coordDim=dimIndex, &
-          staggerloc=staggerloc(staggerlocIndex), &
-          array=coordArrayDst, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_ArrayGet(coordArraySrc, distGrid=distGridSrc, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_ArrayGet(coordArrayDst, distGrid=distGridDst, &
-          dimCount=dimCountDst, deCount=deCountDst, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        if (.NOT. shr_nuopc_methods_Distgrid_Match(distGrid1=distGridSrc, distGrid2=distGridDst, rc=rc)) then
-        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-          msg=subname//": Unable to redistribute coordinates. DistGrids do not match.", &
-          line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-          return  ! bail out
-        endif
-
-        if ( ANY( l_invert == dimIndex )) then
-          call ESMF_GridCompGet(gridcomp, vm=vm, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          call ESMF_VMGet(vm, localPet=localPet, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          if (localPet == 0) then
-            call ESMF_DistGridGet(distGridDst, deCount=deCountDst, rc=rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-            allocate(elementCountPDeDst(deCountDst))
-            call ESMF_DistGridGet(distGridDst, &
-              elementCountPDe=elementCountPDeDst, rc=rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-            sumElementCountPDeDst = SUM(elementCountPDeDst)
-            if (dbug_flag >= 2) then
-              write (numString, "(I10)") sumElementCountPDeDst
-              call ESMF_LogWrite(subname//": sumElementCountPDeDst: "//trim(adjustl(numString)), ESMF_LOGMSG_INFO, rc=dbrc)
-            endif
-
-            allocate(factorList(sumElementCountPDeDst))
-            allocate(factorIndexList(2,sumElementCountPDeDst))
-
-            factorList(:) = 1
-            factorIndexList(1,:) = (/(i, i=1, sumElementCountPDeDst, 1)/)
-            factorIndexList(2,:) = (/(i, i=sumElementCountPDeDst, 1, -1)/)
-
-            if (dbug_flag >= 2) then
-              write (numString, "(I10)") factorIndexList(1,1)
-              write (msgString, "(A)") "Src=>Dst: "//trim(adjustl(numString))//"=>"
-              write (numString, "(I10)") factorIndexList(2,1)
-              write (msgString, "(A)") trim(msgString)//trim(adjustl(numString))
-              write (numString, "(I10)") factorIndexList(1,sumElementCountPDeDst)
-              write (msgString, "(A)") trim(msgString)//" "//trim(adjustl(numString))//"=>"
-              write (numString, "(I10)") factorIndexList(2,sumElementCountPDEDst)
-     	      write (msgString, "(A)") trim(msgString)//trim(adjustl(numString))
-              call ESMF_LogWrite(subname//": Invert Mapping: "//msgString, ESMF_LOGMSG_INFO, rc=dbrc)
-            endif
-
-            call ESMF_ArraySMMStore(srcArray=coordArraySrc, dstArray=coordArrayDst, &
-              routehandle=routehandle, factorList=factorList, &
-              factorIndexList=factorIndexList, rc=rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-            deallocate(elementCountPDeDst)
-            deallocate(factorList)
-            deallocate(factorIndexList)
-          else
-            call ESMF_ArraySMMStore(srcArray=coordArraySrc, dstArray=coordArrayDst, &
-              routehandle=routehandle, rc=rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          endif
-
-          call ESMF_ArraySMM(srcArray=coordArraySrc, dstArray=coordArrayDst, &
-            routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_ArraySMMRelease(routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-        else
-          call ESMF_ArrayRedistStore(coordArraySrc, coordArrayDst, routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_ArrayRedist(coordArraySrc, coordArrayDst, routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_ArrayRedistRelease(routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        endif
-      else
-        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-          msg=subname//": SOURCE GRID MISSING STAGGER LOCATION", &
-          line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-        return  ! bail out
-      endif
-    enddo
-    enddo
-
-    deallocate(l_invert)
-
-    if (dbug_flag > 10) then
-      call ESMF_LogWrite(subname//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-
-  end subroutine shr_nuopc_grid_CopyCoord
-
-  !-----------------------------------------------------------------------------
-
-  subroutine shr_nuopc_grid_CopyItem(gridcomp, gridSrc, gridDst, item, &
-       tolerance, compare, invert, rc)
-
-    use ESMF, only : ESMF_GridComp, ESMF_Grid, ESMF_GridItem_Flag, ESMF_StaggerLoc
-    use ESMF, only : ESMF_GridGetItem, ESMF_GridAddItem
-    use ESMF, only : ESMF_DistGrid, ESMF_Array, ESMF_RouteHandle, ESMF_TypeKind_Flag
-    use ESMF, only : ESMF_CoordSys_Flag, ESMF_LogWrite, ESMF_LOGMSG_INFO
-    use ESMF, only : ESMF_LogSetError, ESMF_GridGet, ESMF_ArrayRedist, ESMF_ArrayRedistStore
-    use ESMF, only : ESMF_ArrayRedistRelease, ESMF_GridGetItem, ESMF_STAGGERLOC_CENTER
-    use ESMF, only : ESMF_RC_ARG_BAD, ESMF_RC_NOT_IMPL, ESMF_ArrayGet
-    use ESMF, only : operator(/=)
-    use shr_nuopc_methods_mod, only : shr_nuopc_methods_Distgrid_Match, shr_nuopc_methods_ChkErr
-
-    ! ----------------------------------------------
-    type(ESMF_GridComp),      intent(in)           :: gridcomp
-    type(ESMF_Grid),          intent(in)           :: gridSrc
-    type(ESMF_Grid),          intent(in)           :: gridDst
-    type(ESMF_GridItem_Flag), intent(in)           :: item(:)
-    real,                     intent(in), optional :: tolerance
-    logical,                  intent(in), optional :: compare
-    integer,                  intent(in), optional :: invert(:)
-    integer,                  intent(out),optional :: rc
-
-    ! Local Variables
-    real                        :: l_tolerance
-    logical                     :: l_compare
-    integer, allocatable        :: l_invert(:)
-    type(ESMF_StaggerLoc)       :: l_staggerloc
-    type(ESMF_DistGrid)         :: distGridSrc, distGridDst
-    type(ESMF_Array)            :: itemArraySrc, itemArrayDst
-    type(ESMF_RouteHandle)      :: routehandle
-    integer                     :: dimCountSrc, dimCountDst
-    type(ESMF_TypeKind_Flag)    :: coordTypeKindSrc, coordTypeKindDst
-    type(ESMF_CoordSys_Flag)    :: coordSysSrc, coordSysDst
-    logical                     :: isPresentSrc, isPresentDst
-    integer                     :: itemIndex
-    integer                     :: localPet
-    character(len=10)           :: numString
-    integer :: dbrc
-    character(len=*), parameter :: subname='(shr_nuopc_methods_Grid_CopyItem)'
-    ! ----------------------------------------------
-
-    if (dbug_flag > 10) then
-      call ESMF_LogWrite(subname//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-
-    l_tolerance = 0.0
-    if (present(tolerance)) l_tolerance = tolerance
-    l_compare = .FALSE.
-    if (present(compare)) l_compare = compare
-    if (present(invert)) then
-      allocate(l_invert(size(invert)))
-      l_invert = invert
-    else
-      allocate(l_invert(1))
-      l_invert = -1
-    endif
-    l_staggerloc = ESMF_STAGGERLOC_CENTER
-
-    call ESMF_GridGet(gridSrc, distGrid=distGridSrc, &
-      dimCount=dimCountSrc, coordTypeKind=coordTypeKindSrc, &
-      coordSys=coordSysSrc, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_GridGet(gridDst, distGrid=distGridDst, &
-      dimCount=dimCountDst, coordTypeKind=coordTypeKindDst, &
-      coordSys=coordSysDst, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    if (.NOT. shr_nuopc_methods_Distgrid_Match(distGrid1=distGridSrc, distGrid2=distGridDst, rc=rc)) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": Unable to redistribute coordinates. DistGrids do not match.", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    if ( dimCountSrc /= dimCountDst) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": DIMCOUNT MISMATCH", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    if ( coordTypeKindSrc /= coordTypeKindDst) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": COORDTYPEKIND MISMATCH", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    if ( coordSysSrc /= coordSysDst) then
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg=subname//": COORDSYS MISMATCH", &
-        line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-      return  ! bail out
-    endif
-
-    do itemIndex=1, size(item)
-      call ESMF_GridGetItem(gridSrc, itemflag=item(itemIndex), &
-        staggerloc=l_staggerloc, isPresent=isPresentSrc, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-      if(isPresentSrc) then
-        call ESMF_GridGetItem(gridSrc, itemflag=item(itemIndex), &
-          staggerloc=l_staggerloc, array=itemArraySrc, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_GridGetItem(gridDst, itemflag=item(itemIndex), &
-          staggerloc=l_staggerloc, isPresent=isPresentDst, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        if(.NOT.isPresentDst) then
-          call ESMF_GridAddItem(gridDst, itemflag=item(itemIndex), &
-            staggerLoc=l_staggerloc, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        else
-          if(l_compare .EQV. .TRUE.) then
-            ! TODO: Compare existing coordinates
-            call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
-              msg=subname//": Cannot compare existing coordinates.", &
-              line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-              return  ! bail out
-          end if
-        endif
-        call ESMF_GridGetItem(gridDst, itemflag=item(itemIndex), &
-          staggerloc=l_staggerloc, array=itemArrayDst, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_ArrayGet(itemArraySrc, distGrid=distGridSrc, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_ArrayGet(itemArrayDst, distGrid=distGridDst, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        if (.NOT. shr_nuopc_methods_Distgrid_Match(distGrid1=distGridSrc, distGrid2=distGridDst, rc=rc)) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-            msg=subname//": Unable to redistribute coordinates. DistGrids do not match.", &
-            line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-            return  ! bail out
-        endif
-
-        if ( ANY( l_invert > 0 )) then
-          ! TODO: Invert Item
-            call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
-              msg=subname//": Cannot invert item.", &
-              line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-              return  ! bail out
-        else
-          call ESMF_ArrayRedistStore(itemArraySrc, itemArrayDst, routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_ArrayRedist(itemArraySrc, itemArrayDst, routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_ArrayRedistRelease(routehandle=routehandle, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-        endif
-      else
-        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-          msg=subname//": SOURCE GRID MISSING ITEM", &
-          line=__LINE__, file=u_FILE_u, rcToReturn=rc)
-        return  ! bail out
-      endif
-    enddo
-
-    deallocate(l_invert)
-
-    if (dbug_flag > 10) then
-      call ESMF_LogWrite(subname//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
-
-  end subroutine shr_nuopc_grid_CopyItem
 
 end module shr_nuopc_grid_mod

--- a/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
@@ -12,7 +12,7 @@ module shr_nuopc_methods_mod
   use ESMF               , only : ESMF_MAXSTR, ESMF_LOGMSG_WARNING, ESMF_POLEMETHOD_ALLAVG
   use med_constants_mod  , only : dbug_flag => med_constants_dbug_flag
 
-  use shr_nuopc_utils_mod, only : shr_nuopc_methods_ChkErr => shr_nuopc_utils_ChkErr
+  use shr_nuopc_utils_mod, only : shr_nuopc_methods_ChkErr => shr_nuopc_utils_ChkErr, shr_nuopc_utils_ChkErr
   implicit none
   private
 
@@ -152,7 +152,7 @@ module shr_nuopc_methods_mod
       end if
       call ESMF_FieldBundleWrite(FB, fname, &
         singleFile=.true., status=ESMF_FILESTATUS_REPLACE, iofmt=ESMF_IOFMT_NETCDF, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_FB_diagnose(FB, 'write '//trim(fname), rc)
 
     elseif (mode == 'read') then
@@ -166,13 +166,13 @@ module shr_nuopc_methods_mod
         ! ignore that field and read the rest, so instead read each field one at a time through ESMF_FieldRead
         !        call ESMF_FieldBundleRead (FB, fname, &
         !          singleFile=.true., iofmt=ESMF_IOFMT_NETCDF, rc=rc)
-        !        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        !        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         !-----------------------------------------------------------------------------------------------------
         call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         do n = 1,fieldCount
           call shr_nuopc_methods_FB_getFieldByName(FB, name, field, rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
           call ESMF_FieldRead (field, fname, iofmt=ESMF_IOFMT_NETCDF, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, file=u_FILE_u)) call ESMF_LogWrite(trim(subname)//' WARNING missing field '//trim(name),rc=dbrc)
@@ -270,10 +270,10 @@ module shr_nuopc_methods_mod
 
     if (present(FBgeom)) then
       call ESMF_FieldBundleGet(FBgeom, fieldCount=fieldCountGeom, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     elseif (present(STgeom)) then
       call ESMF_StateGet(STgeom, itemCount=fieldCountGeom, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//": ERROR FBgeom or STgeom must be passed", ESMF_LOGMSG_INFO, rc=rc)
       rc = ESMF_FAILURE
@@ -293,37 +293,37 @@ module shr_nuopc_methods_mod
       end if
     elseif (present(FBflds)) then
       call ESMF_FieldBundleGet(FBflds, fieldCount=fieldCount, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(lfieldNameList(fieldCount))
       call ESMF_FieldBundleGet(FBflds, fieldNameList=lfieldNameList, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (dbug_flag > 5) then
          call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" fieldNameList from FBflds", ESMF_LOGMSG_INFO, rc=rc)
       end if
     elseif (present(STflds)) then
       call ESMF_StateGet(STflds, itemCount=fieldCount, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(lfieldNameList(fieldCount))
       call ESMF_StateGet(STflds, itemNameList=lfieldNameList, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (dbug_flag > 5) then
          call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" fieldNameList from STflds", ESMF_LOGMSG_INFO, rc=rc)
       end if
     elseif (present(FBgeom)) then
       call ESMF_FieldBundleGet(FBgeom, fieldCount=fieldCount, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(lfieldNameList(fieldCount))
       call ESMF_FieldBundleGet(FBgeom, fieldNameList=lfieldNameList, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (dbug_flag > 5) then
          call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" fieldNameList from FBgeom", ESMF_LOGMSG_INFO, rc=rc)
       end if
     elseif (present(STgeom)) then
       call ESMF_StateGet(STgeom, itemCount=fieldCount, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(lfieldNameList(fieldCount))
       call ESMF_StateGet(STgeom, itemNameList=lfieldNameList, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (dbug_flag > 5) then
          call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" fieldNameList from STflds", ESMF_LOGMSG_INFO, rc=rc)
       end if
@@ -358,13 +358,13 @@ module shr_nuopc_methods_mod
       ! Look at only the first field in either the FBgeom and STgeom to get the grid
       if (present(FBgeom)) then
         call shr_nuopc_methods_FB_getFieldN(FBgeom, 1, lfield, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 5) then
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" grid/mesh from FBgeom", ESMF_LOGMSG_INFO, rc=rc)
         end if
       elseif (present(STgeom)) then
         call shr_nuopc_methods_State_getFieldN(STgeom, 1, lfield, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 5) then
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" grid/mesh from STgeom", ESMF_LOGMSG_INFO, rc=rc)
         end if
@@ -376,7 +376,7 @@ module shr_nuopc_methods_mod
 
       ! Make sure the field is not empty - if it is return with an error
       call ESMF_FieldGet(lfield, status=status, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (status == ESMF_FIELDSTATUS_EMPTY) then
          call ESMF_LogWrite(trim(subname)//":"//trim(lname)//": ERROR field does not have a geom yet ", &
               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
@@ -386,17 +386,17 @@ module shr_nuopc_methods_mod
 
       ! Determine if first field in either FBgeom or STgeom is on a grid or a mesh
       call ESMF_FieldGet(lfield, geomtype=geomtype, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       if (geomtype == ESMF_GEOMTYPE_GRID) then
         call ESMF_FieldGet(lfield, grid=lgrid, staggerloc=staggerloc, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 5) then
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" use grid", ESMF_LOGMSG_INFO, rc=rc)
         end if
       elseif (geomtype == ESMF_GEOMTYPE_MESH) then
         call ESMF_FieldGet(lfield, mesh=lmesh, meshloc=meshloc, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 5) then
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" use mesh", ESMF_LOGMSG_INFO, rc=rc)
         end if
@@ -413,7 +413,7 @@ module shr_nuopc_methods_mod
     !---------------------------------
 
     FBout = ESMF_FieldBundleCreate(name=trim(lname), rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldcountgeom > 0) then
 
@@ -423,10 +423,10 @@ module shr_nuopc_methods_mod
          ! Create the field on either lgrid or lmesh
         if (geomtype == ESMF_GEOMTYPE_GRID) then
           field = ESMF_FieldCreate(lgrid, ESMF_TYPEKIND_R8, staggerloc=staggerloc, name=lfieldNameList(n), rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         elseif (geomtype == ESMF_GEOMTYPE_MESH) then
           field = ESMF_FieldCreate(lmesh, ESMF_TYPEKIND_R8, meshloc=meshloc, name=lfieldNameList(n), rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         else  ! geomtype
           call ESMF_LogWrite(trim(subname)//": ERROR no grid/mesh for field ", ESMF_LOGMSG_INFO, rc=rc)
           rc = ESMF_FAILURE
@@ -435,7 +435,7 @@ module shr_nuopc_methods_mod
 
         ! Add the created field bundle FBout
         call ESMF_FieldBundleAdd(FBout, (/field/), rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 1) then
           call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" adding field "//trim(lfieldNameList(n)), &
                ESMF_LOGMSG_INFO, rc=dbrc)
@@ -448,7 +448,7 @@ module shr_nuopc_methods_mod
     deallocate(lfieldNameList)
 
     call shr_nuopc_methods_FB_reset(FBout, value=spval_init, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -483,7 +483,7 @@ module shr_nuopc_methods_mod
     fieldname = ' '
 
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldnum > fieldCount) then
       call ESMF_LogWrite(trim(subname)//": ERROR fieldnum > fieldCount ", ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
@@ -493,7 +493,7 @@ module shr_nuopc_methods_mod
 
     allocate(lfieldnamelist(fieldCount))
     call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     fieldname = lfieldnamelist(fieldnum)
 
@@ -530,10 +530,10 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_FB_getNameN(FB, fieldnum, name, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_FieldBundleGet(FB, fieldName=name, field=field, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -564,7 +564,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_FieldBundleGet(FB, fieldName=fieldname, field=field, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -599,7 +599,7 @@ module shr_nuopc_methods_mod
     fieldname = ' '
 
     call ESMF_StateGet(State, itemCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldnum > fieldCount) then
       call ESMF_LogWrite(trim(subname)//": ERROR fieldnum > fieldCount ", ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
@@ -609,7 +609,7 @@ module shr_nuopc_methods_mod
 
     allocate(lfieldnamelist(fieldCount))
     call ESMF_StateGet(State, itemNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     fieldname = lfieldnamelist(fieldnum)
 
@@ -652,7 +652,7 @@ module shr_nuopc_methods_mod
 
       nullify(fieldList)
       call NUOPC_GetStateMemberLists(state, fieldList=fieldList, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       fieldnum = 0
       if (associated(fieldList)) then
         fieldnum = size(fieldList)
@@ -663,12 +663,12 @@ module shr_nuopc_methods_mod
 
       fieldnum = 0
       call ESMF_StateGet(State, itemCount=itemCount, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       if (itemCount > 0) then
         allocate(itemTypeList(itemCount))
         call ESMF_StateGet(State, itemTypeList=itemTypeList, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         do n = 1,itemCount
           if (itemTypeList(n) == ESMF_STATEITEM_FIELD) fieldnum=fieldnum+1
@@ -708,10 +708,10 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_State_getNameN(State, fieldnum, name, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_StateGet(State, itemName=name, field=field, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -743,7 +743,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_StateGet(State, itemName=fieldname, field=field, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -779,18 +779,18 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(lfieldnamelist(fieldCount))
     call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     do n = 1, fieldCount
       call ESMF_FieldBundleGet(FB, fieldName=lfieldnamelist(n), field=field, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call ESMF_FieldDestroy(field, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
     call ESMF_FieldBundleDestroy(FB, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     deallocate(lfieldnamelist)
 
     if (dbug_flag > 10) then
@@ -834,14 +834,14 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(lfieldnamelist(fieldCount))
     call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, fieldCount
       call shr_nuopc_methods_FB_SetFldPtr(FB, lfieldnamelist(n), lvalue, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
 
     deallocate(lfieldnamelist)
@@ -885,9 +885,9 @@ module shr_nuopc_methods_mod
         shr_nuopc_methods_FB_FldChk(FBout, trim(fldout), rc=rc)) then
 
       call shr_nuopc_methods_FB_GetFldPtr(FBin, trim(fldin), dataPtrIn1, dataPtrIn2, lrankIn, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_FB_GetFldPtr(FBout, trim(fldout), dataPtrOut1, dataPtrOut2, lrankOut, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       if (lrankIn /= lrankOut) then
         call ESMF_LogWrite(trim(subname)//": ERROR FBin and FBout different rank", ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
@@ -1033,7 +1033,7 @@ module shr_nuopc_methods_mod
             return
           endif
           call shr_nuopc_methods_FB_FieldRegrid(FBin, shortnames(n), FBout, shortnames(n), bilnrmap,rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         elseif (mappings(n) == "conservefrac") then
           if (.not. okconsf) then
@@ -1043,7 +1043,7 @@ module shr_nuopc_methods_mod
             return
           endif
           call shr_nuopc_methods_FB_FieldRegrid(FBin, shortnames(n), FBout,shortnames(n), consfmap, rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         elseif (mappings(n) == "conservedst") then
           if (.not. okconsd) then
@@ -1053,7 +1053,7 @@ module shr_nuopc_methods_mod
             return
           endif
           call shr_nuopc_methods_FB_FieldRegrid(FBin, shortnames(n), FBout,shortnames(n), consdmap, rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         elseif (mappings(n) == 'patch') then
           if (.not. okpatch) then
@@ -1063,7 +1063,7 @@ module shr_nuopc_methods_mod
             return
           endif
           call shr_nuopc_methods_FB_FieldRegrid(FBin, shortnames(n), FBout,shortnames(n), patchmap,rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         elseif (mappings(n) == 'copy') then
           !-------------------------------------------
@@ -1082,11 +1082,11 @@ module shr_nuopc_methods_mod
                       " fld="//trim(shortnames(n)), ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
               end if
               call shr_nuopc_methods_FB_FieldRegrid(FBin ,shortnames(n), FBout, shortnames(n), consfmap,rc)
-              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+              if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
             endif
           else
             call shr_nuopc_methods_FB_FieldRegrid(FBin ,shortnames(n), FBout,shortnames(n), fcopymap,rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+            if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
           endif
 
         else
@@ -1119,7 +1119,6 @@ module shr_nuopc_methods_mod
     use ESMF, only : ESMF_FieldBundle, ESMF_RouteHandle, ESMF_FieldRegrid, ESMF_Field
     use ESMF, only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegridStore, ESMF_SparseMatrixWrite
     use med_constants_mod, only : R8
-    use mpi, only : mpi_comm_rank, MPI_COMM_WORLD
     type(ESMF_FieldBundle), intent(inout) :: FBin
     character(len=*)      , intent(in)    :: fldin
     type(ESMF_FieldBundle), intent(inout) :: FBout
@@ -1146,14 +1145,14 @@ module shr_nuopc_methods_mod
         shr_nuopc_methods_FB_FldChk(FBout, trim(fldout), rc=rc)) then
 
       call shr_nuopc_methods_FB_getFieldByName(FBin, trim(fldin), field1, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_FB_getFieldByName(FBout, trim(fldout), field2, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_FieldRegrid(field1, field2, routehandle=RH, &
         termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=.true., rc=rc)
 
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
    else
 
       if (dbug_flag > 1) then
@@ -1225,7 +1224,7 @@ module shr_nuopc_methods_mod
     endif
 
     call shr_nuopc_methods_FB_GetFldPtr(FBout, trim(fnameout), fldptr2=dataOut, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     lb1 = lbound(dataOut,1)
     ub1 = ubound(dataOut,1)
     lb2 = lbound(dataOut,2)
@@ -1277,7 +1276,7 @@ module shr_nuopc_methods_mod
       if (n == 1 .and. present(FBinA)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinA, trim(fnameA), fldptr2=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtA)) then
           wgtfound = .true.
           wgt => wgtA
@@ -1286,7 +1285,7 @@ module shr_nuopc_methods_mod
       elseif (n == 2 .and. present(FBinB)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinB, trim(fnameB), fldptr2=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtB)) then
           wgtfound = .true.
           wgt => wgtB
@@ -1295,7 +1294,7 @@ module shr_nuopc_methods_mod
       elseif (n == 3 .and. present(FBinC)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinC, trim(fnameC), fldptr2=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtC)) then
           wgtfound = .true.
           wgt => wgtC
@@ -1304,7 +1303,7 @@ module shr_nuopc_methods_mod
       elseif (n == 4 .and. present(FBinD)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinD, trim(fnameD), fldptr2=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtD)) then
           wgtfound = .true.
           wgt => wgtD
@@ -1313,7 +1312,7 @@ module shr_nuopc_methods_mod
       elseif (n == 5 .and. present(FBinE)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinE, trim(fnameE), fldptr2=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtE)) then
           wgtfound = .true.
           wgt => wgtE
@@ -1414,7 +1413,7 @@ module shr_nuopc_methods_mod
     endif
 
     call shr_nuopc_methods_FB_GetFldPtr(FBout, trim(fnameout), fldptr1=dataOut, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     lb1 = lbound(dataOut,1)
     ub1 = ubound(dataOut,1)
     allocate(wgt(lb1:ub1))
@@ -1464,7 +1463,7 @@ module shr_nuopc_methods_mod
       if (n == 1 .and. present(FBinA)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinA, trim(fnameA), fldptr1=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtA)) then
           wgtfound = .true.
           wgt => wgtA
@@ -1473,7 +1472,7 @@ module shr_nuopc_methods_mod
       elseif (n == 2 .and. present(FBinB)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinB, trim(fnameB), fldptr1=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtB)) then
           wgtfound = .true.
           wgt => wgtB
@@ -1482,7 +1481,7 @@ module shr_nuopc_methods_mod
       elseif (n == 3 .and. present(FBinC)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinC, trim(fnameC), fldptr1=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtC)) then
           wgtfound = .true.
           wgt => wgtC
@@ -1491,7 +1490,7 @@ module shr_nuopc_methods_mod
       elseif (n == 4 .and. present(FBinD)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinD, trim(fnameD), fldptr1=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtD)) then
           wgtfound = .true.
           wgt => wgtD
@@ -1500,7 +1499,7 @@ module shr_nuopc_methods_mod
       elseif (n == 5 .and. present(FBinE)) then
         FBinfound = .true.
         call shr_nuopc_methods_FB_GetFldPtr(FBinE, trim(fnameE), fldptr1=dataPtr, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (present(wgtE)) then
           wgtfound = .true.
           wgt => wgtE
@@ -1577,14 +1576,14 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_StateGet(State, itemCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(lfieldnamelist(fieldCount))
     call ESMF_StateGet(State, itemNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, fieldCount
       call shr_nuopc_methods_State_SetFldPtr(State, lfieldnamelist(n), lvalue, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
 
     deallocate(lfieldnamelist)
@@ -1630,18 +1629,18 @@ module shr_nuopc_methods_mod
        end if
        !call ESMF_LogWrite(trim(subname)//": WARNING count is 0 set avg to spval", ESMF_LOGMSG_INFO, rc=dbrc)
        !call shr_nuopc_methods_FB_reset(FB, value=spval, rc=rc)
-       !if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       !if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     else
 
       call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       allocate(lfieldnamelist(fieldCount))
       call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       do n = 1, fieldCount
         call shr_nuopc_methods_FB_GetFldPtr(FB, lfieldnamelist(n), dataPtr1, dataPtr2, lrank, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         if (lrank == 0) then
           ! no local data
@@ -1708,18 +1707,18 @@ module shr_nuopc_methods_mod
 
     ! Determine number of fields in field bundle and allocate memory for lfieldnamelist
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(lfieldnamelist(fieldCount))
 
     ! Get the fields in the field bundle
     call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! For each field in the bundle, get its memory location and print out the field
     do n = 1, fieldCount
        call shr_nuopc_methods_FB_GetFldPtr(FB, lfieldnamelist(n), &
             fldptr1=dataPtr1d, fldptr2=dataPtr2d, rank=lrank, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        if (lrank == 0) then
           ! no local data
@@ -1796,7 +1795,7 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_ArrayGet(Array, farrayPtr=dataPtr3d, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write(msgString,'(A,3g14.7)') trim(subname)//' '//trim(lstring), &
         minval(dataPtr3d), maxval(dataPtr3d), sum(dataPtr3d)
@@ -1845,16 +1844,16 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_StateGet(State, itemCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(lfieldnamelist(fieldCount))
 
     call ESMF_StateGet(State, itemNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, fieldCount
        call shr_nuopc_methods_State_GetFldPtr(State, lfieldnamelist(n), &
             fldptr1=dataPtr1d, fldptr2=dataPtr2d, rank=lrank, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
        if (dbug_flag > 1) then
           if (lrank == 0) then
              ! no local data
@@ -1930,7 +1929,7 @@ module shr_nuopc_methods_mod
     endif
 
     call shr_nuopc_methods_FB_GetFldPtr(FB, fieldname, dataPtr1d, dataPtr2d, lrank, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
        ! no local data
@@ -1987,7 +1986,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_FB_accum(FBout, FBin, copy=.true., rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -2016,7 +2015,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_FB_accum(STout, FBin, copy=.true., rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -2044,7 +2043,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_FB_accum(FBout, STin, copy=.true., rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -2090,19 +2089,19 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_FieldBundleGet(FBout, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(lfieldnamelist(fieldCount))
     call ESMF_FieldBundleGet(FBout, fieldNameList=lfieldnamelist, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, fieldCount
       call ESMF_FieldBundleGet(FBin, fieldName=lfieldnamelist(n), isPresent=exists, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (exists) then
         call shr_nuopc_methods_FB_GetFldPtr(FBin,  lfieldnamelist(n), dataPtri1, dataPtri2, lranki, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         call shr_nuopc_methods_FB_GetFldPtr(FBout, lfieldnamelist(n), dataPtro1, dataPtro2, lranko, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         if (lranki == 1 .and. lranko == 1) then
 
@@ -2210,13 +2209,13 @@ module shr_nuopc_methods_mod
     call ESMF_FieldBundleGet(FBout, fieldNameList=lfieldnamelist, rc=rc)
     do n = 1, fieldCount
       call ESMF_StateGet(STin, itemName=lfieldnamelist(n), itemType=itemType, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (itemType /= ESMF_STATEITEM_NOTFOUND) then
 
         call shr_nuopc_methods_State_GetFldPtr(STin, lfieldnamelist(n), dataPtrS1, dataPtrS2, lrankS, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         call shr_nuopc_methods_FB_GetFldPtr(FBout, lfieldnamelist(n), dataPtrB1, dataPtrB2, lrankB, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         if (lrankB == 0 .and. lrankS == 0) then
 
@@ -2329,13 +2328,13 @@ module shr_nuopc_methods_mod
     call ESMF_FieldBundleGet(FBin, fieldNameList=lfieldnamelist, rc=rc)
     do n = 1, fieldCount
       call ESMF_StateGet(STout, itemName=lfieldnamelist(n), itemType=itemType, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (itemType /= ESMF_STATEITEM_NOTFOUND) then
 
         call shr_nuopc_methods_FB_GetFldPtr(FBin, lfieldnamelist(n), dataPtrB1, dataPtrB2, lrankB, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         call shr_nuopc_methods_State_GetFldPtr(STout, lfieldnamelist(n), dataPtrS1, dataPtrS2, lrankS, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         if (lrankB == 0 .and. lrankS == 0) then
 
@@ -2426,7 +2425,7 @@ module shr_nuopc_methods_mod
     shr_nuopc_methods_FB_FldChk = .false.
 
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), isPresent=isPresent, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent) then
        shr_nuopc_methods_FB_FldChk = .true.
     endif
@@ -2484,7 +2483,7 @@ module shr_nuopc_methods_mod
     lrank = -99
 
     call ESMF_FieldGet(field, status=status, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (status /= ESMF_FIELDSTATUS_COMPLETE) then
       lrank = 0
@@ -2498,17 +2497,17 @@ module shr_nuopc_methods_mod
     else
 
       call ESMF_FieldGet(field, geomtype=geomtype, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       if (geomtype == ESMF_GEOMTYPE_GRID) then
         call ESMF_FieldGet(field, rank=lrank, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       elseif (geomtype == ESMF_GEOMTYPE_MESH) then
         lrank = 1
         call ESMF_FieldGet(field, mesh=lmesh, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         call ESMF_MeshGet(lmesh, numOwnedNodes=nnodes, numOwnedElements=nelements, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         if (nnodes == 0 .and. nelements == 0) lrank = 0
       else  ! geomtype
          call ESMF_LogWrite(trim(subname)//": ERROR geomtype not supported ", &
@@ -2528,7 +2527,7 @@ module shr_nuopc_methods_mod
           return
         endif
         call ESMF_FieldGet(field, farrayPtr=fldptr1, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       elseif (lrank == 2) then
         if (.not.present(fldptr2)) then
            call ESMF_LogWrite(trim(subname)//": ERROR missing rank=2 array ", &
@@ -2537,7 +2536,7 @@ module shr_nuopc_methods_mod
           return
         endif
         call ESMF_FieldGet(field, farrayPtr=fldptr2, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       else
          call ESMF_LogWrite(trim(subname)//": ERROR in rank ", &
               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
@@ -2601,11 +2600,11 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), field=lfield, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_nuopc_methods_Field_GetFldPtr(lfield, &
          fldptr1=fldptr1, fldptr2=fldptr2, rank=lrank, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (present(rank)) then
       rank = lrank
@@ -2642,7 +2641,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_FB_GetFldPtr(FB, fldname, fldptr1, fldptr2, lrank, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
       ! no local data
@@ -2700,11 +2699,11 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_StateGet(ST, itemName=trim(fldname), field=lfield, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_nuopc_methods_Field_GetFldPtr(lfield, &
          fldptr1=fldptr1, fldptr2=fldptr2, rank=lrank, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (present(rank)) then
       rank = lrank
@@ -2741,7 +2740,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call shr_nuopc_methods_State_GetFldPtr(ST, fldname, fldptr1, fldptr2, lrank, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
       ! no local data
@@ -2784,7 +2783,7 @@ module shr_nuopc_methods_mod
     if (lbound(fldptr2,1) /= lbound(fldptr1,1) .or. &
         ubound(fldptr2,1) /= ubound(fldptr1,1)) then
       call ESMF_LogWrite(trim(subname)//": ERROR in data size "//trim(cstring), ESMF_LOGMSG_ERROR, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       write(msgString,*) trim(subname)//': fldptr1 ',lbound(fldptr1),ubound(fldptr1)
       call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
       write(msgString,*) trim(subname)//': fldptr2 ',lbound(fldptr2),ubound(fldptr2)
@@ -2823,7 +2822,7 @@ module shr_nuopc_methods_mod
         ubound(fldptr2,2) /= ubound(fldptr1,2) .or. &
         ubound(fldptr2,1) /= ubound(fldptr1,1)) then
       call ESMF_LogWrite(trim(subname)//": ERROR in data size "//trim(cstring), ESMF_LOGMSG_ERROR, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       write(msgString,*) trim(subname)//': fldptr2 ',lbound(fldptr2),ubound(fldptr2)
       call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=dbrc)
       write(msgString,*) trim(subname)//': fldptr1 ',lbound(fldptr1),ubound(fldptr1)
@@ -2857,13 +2856,13 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_StateGet(state, itemCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
       call shr_nuopc_methods_State_GetFieldN(state, 1, lfield, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Field_GeomPrint(lfield, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO, rc=dbrc)
     endif  ! fieldCount > 0
@@ -2894,12 +2893,12 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
 
       call shr_nuopc_methods_Field_GeomPrint(lfield, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO, rc=dbrc)
     endif  ! fieldCount > 0
@@ -2935,7 +2934,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_FieldGet(field, status=status, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (status == ESMF_FIELDSTATUS_EMPTY) then
        call ESMF_LogWrite(trim(subname)//":"//trim(string)//": ERROR field does not have a geom yet ", &
             ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
@@ -2944,37 +2943,37 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_FieldGet(field, geomtype=geomtype, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (geomtype == ESMF_GEOMTYPE_GRID) then
       call ESMF_FieldGet(field, grid=lgrid, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Grid_Print(lgrid, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     elseif (geomtype == ESMF_GEOMTYPE_MESH) then
       call ESMF_FieldGet(field, mesh=lmesh, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Mesh_Print(lmesh, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
 
     call shr_nuopc_methods_Field_GetFldPtr(field, &
          fldptr1=dataPtr1, fldptr2=dataPtr2, rank=lrank, abort=.false., rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
       ! no local data
     elseif (lrank == 1) then
       write (msgString,*) trim(subname)//":"//trim(string)//": dataptr bounds dim=1 ",lbound(dataptr1,1),ubound(dataptr1,1)
       call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     elseif (lrank == 2) then
       write (msgString,*) trim(subname)//":"//trim(string)//": dataptr bounds dim=1 ",lbound(dataptr2,1),ubound(dataptr2,1)
       call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       write (msgString,*) trim(subname)//":"//trim(string)//": dataptr bounds dim=2 ",lbound(dataptr2,2),ubound(dataptr2,2)
       call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     elseif (lrank == 0) then
       ! means data allocation does not exist yet
       continue
@@ -3020,129 +3019,129 @@ module shr_nuopc_methods_mod
 
     call ESMF_MeshGet(mesh, elementDistGridIsPresent=elemDGPresent, &
          nodalDistgridIsPresent=nodeDGPresent, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_MeshGet(mesh, status=meshStatus, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! first get the distgrid, which should be available
     if (elemDGPresent) then
        call ESMF_MeshGet(mesh, elementDistgrid=distgrid, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//": distGrid=element"
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_DistGridGet(distgrid, deLayout=deLayout, dimCount=dimCount, &
             tileCount=tileCount, deCount=deCount, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    dimCount=", dimCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    tileCount=", tileCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    deCount=", deCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_DELayoutGet(deLayout, localDeCount=localDeCount, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        write (msgString,*) trim(subname)//":"//trim(string)//":    localDeCount=", localDeCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        ! allocate minIndexPTile and maxIndexPTile accord. to dimCount and tileCount
        allocate(minIndexPTile(dimCount, tileCount), &
             maxIndexPTile(dimCount, tileCount))
-       
+
        ! get minIndex and maxIndex arrays
        call ESMF_DistGridGet(distgrid, minIndexPTile=minIndexPTile, &
             maxIndexPTile=maxIndexPTile, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    minIndexPTile=", minIndexPTile
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    maxIndexPTile=", maxIndexPTile
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
-       deallocate(minIndexPTile, maxIndexPTile)       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       deallocate(minIndexPTile, maxIndexPTile)
 
     endif
 
     if (nodeDGPresent) then
        call ESMF_MeshGet(mesh, nodalDistgrid=distgrid, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        write (msgString,*) trim(subname)//":"//trim(string)//": distGrid=nodal"
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_DistGridGet(distgrid, deLayout=deLayout, dimCount=dimCount, &
             tileCount=tileCount, deCount=deCount, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    dimCount=", dimCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    tileCount=", tileCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    deCount=", deCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_DELayoutGet(deLayout, localDeCount=localDeCount, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        write (msgString,*) trim(subname)//":"//trim(string)//":    localDeCount=", localDeCount
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
- 
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        ! allocate minIndexPTile and maxIndexPTile accord. to dimCount and tileCount
        allocate(minIndexPTile(dimCount, tileCount), &
             maxIndexPTile(dimCount, tileCount))
-       
+
        ! get minIndex and maxIndex arrays
        call ESMF_DistGridGet(distgrid, minIndexPTile=minIndexPTile, &
             maxIndexPTile=maxIndexPTile, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    minIndexPTile=", minIndexPTile
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//":    maxIndexPTile=", maxIndexPTile
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
-       deallocate(minIndexPTile, maxIndexPTile)       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       deallocate(minIndexPTile, maxIndexPTile)
 
     endif
 
     if (.not. elemDGPresent .and. .not. nodeDGPresent) then
-       call ESMF_LogWrite(trim(subname)//": cannot print distgrid from mesh", & 
+       call ESMF_LogWrite(trim(subname)//": cannot print distgrid from mesh", &
             ESMF_LOGMSG_WARNING, rc=rc)
        return
     endif
 
     ! if mesh is complete, also get additional parameters
-    if (meshStatus==ESMF_MESHSTATUS_COMPLETE) then   
+    if (meshStatus==ESMF_MESHSTATUS_COMPLETE) then
        ! access localDeCount to show this is a real Grid
        call ESMF_MeshGet(mesh, parametricDim=pdim, spatialDim=sdim, &
             numOwnedNodes=nnodes, numOwnedElements=nelements, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-       
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
        write (msgString,*) trim(subname)//":"//trim(string)//": parametricDim=", pdim
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
        write (msgString,*) trim(subname)//":"//trim(string)//": spatialDim=", sdim
@@ -3151,9 +3150,9 @@ module shr_nuopc_methods_mod
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
        write (msgString,*) trim(subname)//":"//trim(string)//": numOwnedElements=", nelements
        call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-       if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
-       
+
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
     endif
@@ -3192,27 +3191,27 @@ module shr_nuopc_methods_mod
 
     ! access localDeCount to show this is a real Grid
     call ESMF_GridGet(grid, localDeCount=localDeCount, distgrid=distgrid, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": localDeCount=", localDeCount
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get dimCount and tileCount
     call ESMF_DistGridGet(distgrid, dimCount=dimCount, tileCount=tileCount, deCount=deCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": dimCount=", dimCount
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": tileCount=", tileCount
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": deCount=", deCount
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! allocate minIndexPTile and maxIndexPTile accord. to dimCount and tileCount
     allocate(minIndexPTile(dimCount, tileCount), &
@@ -3221,40 +3220,40 @@ module shr_nuopc_methods_mod
     ! get minIndex and maxIndex arrays
     call ESMF_DistGridGet(distgrid, minIndexPTile=minIndexPTile, &
        maxIndexPTile=maxIndexPTile, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": minIndexPTile=", minIndexPTile
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": maxIndexPTile=", maxIndexPTile
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(minIndexPTile, maxIndexPTile)
 
     ! get staggerlocCount, arbDimCount
 !    call ESMF_GridGet(grid, staggerlocCount=staggerlocCount, rc=rc)
-!    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+!    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
 !    write (msgString,*) trim(subname)//":"//trim(string)//": staggerlocCount=", staggerlocCount
 !    call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-!    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+!    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
 !    call ESMF_GridGet(grid, arbDimCount=arbDimCount, rc=rc)
-!    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+!    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
 !    write (msgString,*) trim(subname)//":"//trim(string)//": arbDimCount=", arbDimCount
 !    call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-!    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+!    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get rank
     call ESMF_GridGet(grid, rank=rank, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     write (msgString,*) trim(subname)//":"//trim(string)//": rank=", rank
     call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n1 = 1,2
       if (n1 == 1) then
@@ -3266,28 +3265,28 @@ module shr_nuopc_methods_mod
       else
         rc = ESMF_FAILURE
         call ESMF_LogWrite(trim(subname)//":staggerloc failure", ESMF_LOGMSG_INFO, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
       call ESMF_GridGetCoord(grid, staggerloc=staggerloc, isPresent=isPresent, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       write (msgString,*) trim(subname)//":"//trim(staggerstr)//" present=",isPresent
       call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (isPresent) then
         do n3 = 0,localDECount-1
         do n2 = 1,dimCount
           if (rank == 1) then
             call ESMF_GridGetCoord(grid,coordDim=n2,localDE=n3,staggerloc=staggerloc,farrayPtr=fldptr1,rc=rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+            if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
             write (msgString,'(a,2i4,2f16.8)') trim(subname)//":"//trim(staggerstr)//" coord=",n2,n3,minval(fldptr1),maxval(fldptr1)
           endif
           if (rank == 2) then
             call ESMF_GridGetCoord(grid,coordDim=n2,localDE=n3,staggerloc=staggerloc,farrayPtr=fldptr2,rc=rc)
-            if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+            if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
             write (msgString,'(a,2i4,2f16.8)') trim(subname)//":"//trim(staggerstr)//" coord=",n2,n3,minval(fldptr2),maxval(fldptr2)
           endif
           call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
         enddo
         enddo
       endif
@@ -3328,27 +3327,27 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_ClockGet(clock,currtime=time,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeGet(time,timestring=timestr,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_LogWrite(trim(lstring)//": currtime = "//trim(timestr), ESMF_LOGMSG_INFO, rc=dbrc)
 
     call ESMF_ClockGet(clock,starttime=time,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeGet(time,timestring=timestr,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_LogWrite(trim(lstring)//": startime = "//trim(timestr), ESMF_LOGMSG_INFO, rc=dbrc)
 
     call ESMF_ClockGet(clock,stoptime=time,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeGet(time,timestring=timestr,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_LogWrite(trim(lstring)//": stoptime = "//trim(timestr), ESMF_LOGMSG_INFO, rc=dbrc)
 
     call ESMF_ClockGet(clock,timestep=timestep,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeIntervalGet(timestep,timestring=timestr,rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_LogWrite(trim(lstring)//": timestep = "//trim(timestr), ESMF_LOGMSG_INFO, rc=dbrc)
 
     if (dbug_flag > 5) then
@@ -3386,12 +3385,12 @@ module shr_nuopc_methods_mod
     !--- elements ---
 
     call ESMF_MeshGet(mesh, spatialDim=ndims, numownedElements=lsize, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(rawdata(ndims*lsize))
     allocate(coord(lsize))
 
     call ESMF_MeshGet(mesh, elementDistgrid=distgrid, ownedElemCoords=rawdata, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1,ndims
       name = "unknown"
@@ -3401,13 +3400,13 @@ module shr_nuopc_methods_mod
       i = 2*(l-1) + n
       coord(l) = rawdata(i)
       array = ESMF_ArrayCreate(distgrid, farrayPtr=coord, name=name, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
     enddo
 
@@ -3416,12 +3415,12 @@ module shr_nuopc_methods_mod
     !--- nodes ---
 
     call ESMF_MeshGet(mesh, spatialDim=ndims, numownedNodes=lsize, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     allocate(rawdata(ndims*lsize))
     allocate(coord(lsize))
 
     call ESMF_MeshGet(mesh, nodalDistgrid=distgrid, ownedNodeCoords=rawdata, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1,ndims
       name = "unknown"
@@ -3431,13 +3430,13 @@ module shr_nuopc_methods_mod
       i = 2*(l-1) + n
       coord(l) = rawdata(i)
       array = ESMF_ArrayCreate(distgrid, farrayPtr=coord, name=name, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
     enddo
 
@@ -3471,13 +3470,13 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_StateGet(state, itemCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
       call shr_nuopc_methods_State_getFieldN(state, 1, lfield, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Field_GeomWrite(lfield, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO, rc=dbrc)
     endif  ! fieldCount > 0
@@ -3508,13 +3507,13 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
       call shr_nuopc_methods_FB_getFieldN(FB, 1, lfield, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Field_GeomWrite(lfield, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO, rc=dbrc)
     endif  ! fieldCount > 0
@@ -3546,7 +3545,7 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call ESMF_FieldGet(field, status=status, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (status == ESMF_FIELDSTATUS_EMPTY) then
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": ERROR field does not have a geom yet ", ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
       rc = ESMF_FAILURE
@@ -3554,18 +3553,18 @@ module shr_nuopc_methods_mod
     endif
 
     call ESMF_FieldGet(field, geomtype=geomtype, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (geomtype == ESMF_GEOMTYPE_GRID) then
       call ESMF_FieldGet(field, grid=lgrid, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Grid_Write(lgrid, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     elseif (geomtype == ESMF_GEOMTYPE_MESH) then
       call ESMF_FieldGet(field, mesh=lmesh, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       call shr_nuopc_methods_Mesh_Write(lmesh, string, rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
 
     if (dbug_flag > 10) then
@@ -3601,64 +3600,64 @@ module shr_nuopc_methods_mod
     ! -- centers --
 
     call ESMF_GridGetCoord(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent) then
       name = "lon_center"
       call ESMF_GridGetCoord(grid, coordDim=1, staggerLoc=ESMF_STAGGERLOC_CENTER, array=array, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArraySet(array, name=name, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       name = "lat_center"
       call ESMF_GridGetCoord(grid, coordDim=2, staggerLoc=ESMF_STAGGERLOC_CENTER, array=array, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArraySet(array, name=name, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
 
     ! -- corners --
 
     call ESMF_GridGetCoord(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, isPresent=isPresent, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent) then
       name = "lon_corner"
       call ESMF_GridGetCoord(grid, coordDim=1, staggerLoc=ESMF_STAGGERLOC_CORNER, array=array, rc=rc)
       if (.not. ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) then
         call ESMF_ArraySet(array, name=name, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
 
       name = "lat_corner"
       call ESMF_GridGetCoord(grid, coordDim=2, staggerLoc=ESMF_STAGGERLOC_CORNER, array=array, rc=rc)
       if (.not. ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) then
         call ESMF_ArraySet(array, name=name, rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
         call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-        if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     endif
 
@@ -3666,38 +3665,38 @@ module shr_nuopc_methods_mod
 
     name = "mask"
     call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_MASK, staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent) then
       call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, itemflag=ESMF_GRIDITEM_MASK, array=array, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArraySet(array, name=name, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
 
     ! -- area --
 
     name = "area"
     call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_AREA, staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent) then
       call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, itemflag=ESMF_GRIDITEM_AREA, array=array, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArraySet(array, name=name, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//trim(name), rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
 
     if (dbug_flag > 10) then
@@ -3733,11 +3732,11 @@ module shr_nuopc_methods_mod
 
     call ESMF_DistGridGet(distGrid1, &
       dimCount=dimCount1, tileCount=tileCount1, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_DistGridGet(distGrid2, &
       dimCount=dimCount2, tileCount=tileCount2, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ( dimCount1 /= dimCount2) then
       shr_nuopc_methods_Distgrid_Match = .false.
@@ -3766,13 +3765,13 @@ module shr_nuopc_methods_mod
       elementCountPTile=elementCountPTile1, &
       minIndexPTile=minIndexPTile1, &
       maxIndexPTile=maxIndexPTile1, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_DistGridGet(distGrid2, &
       elementCountPTile=elementCountPTile2, &
       minIndexPTile=minIndexPTile2, &
       maxIndexPTile=maxIndexPTile2, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ( ANY((elementCountPTile1 - elementCountPTile2) .NE. 0) ) then
       shr_nuopc_methods_Distgrid_Match = .false.
@@ -3816,29 +3815,26 @@ module shr_nuopc_methods_mod
 
 !================================================================================
 
-  subroutine shr_nuopc_methods_State_GetScalar(State, scalar_id, value, mpicom, flds_scalar_name, flds_scalar_num, rc)
+  subroutine shr_nuopc_methods_State_GetScalar(State, scalar_id, value, flds_scalar_name, flds_scalar_num, rc)
     use med_constants_mod , only : R8
-   !use mpi               , only : mpi_comm_rank, MPI_REAL8, mpi_bcast !TODO: mpi_bcast use does not seem to work on hobart
-    use mpi
     use ESMF              , only : ESMF_SUCCESS, ESMF_State, ESMF_StateGet, ESMF_Field, ESMF_FieldGet
     use ESMF              , only : ESMF_FAILURE, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_LogWrite
-    use ESMF              , only : ESMF_LOGMSG_INFO
+    use ESMF              , only : ESMF_LOGMSG_INFO, ESMF_VM, ESMF_VMBroadCast, ESMF_VMGetCurrent
 
     ! ----------------------------------------------
     ! Get scalar data from State for a particular name and broadcast it to all other pets
-    ! in mpicom
     ! ----------------------------------------------
 
     type(ESMF_State), intent(in)     :: State
     integer,          intent(in)     :: scalar_id
     real(R8),         intent(out)    :: value
-    integer,          intent(in)     :: mpicom
     character(len=*), intent(in)     :: flds_scalar_name
     integer,          intent(in)     :: flds_scalar_num
     integer,          intent(inout)  :: rc
 
     ! local variables
     integer           :: mytask, ierr, len
+    type(ESMF_VM)     :: vm
     type(ESMF_Field)  :: field
     real(R8), pointer :: farrayptr(:,:)
     integer           :: dbrc
@@ -3846,41 +3842,40 @@ module shr_nuopc_methods_mod
 
     rc = ESMF_SUCCESS
 
-    call MPI_COMM_RANK(mpicom, mytask, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u, mpierr=.true.)) return
+    call ESMF_VMGetCurrent(vm, rc=rc)
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call ESMF_StateGet(State, itemName=trim(flds_scalar_name), field=field, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (mytask == 0) then
       call ESMF_FieldGet(field, farrayPtr = farrayptr, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (scalar_id < 0 .or. scalar_id > flds_scalar_num) then
         call ESMF_LogWrite(trim(subname)//": ERROR in scalar_id", ESMF_LOGMSG_INFO, line=__LINE__, file=u_FILE_u, rc=dbrc)
         rc = ESMF_FAILURE
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
       endif
-      value = farrayptr(1,scalar_id)
     endif
+    call ESMF_VMBroadCast(vm, farrayptr(:,scalar_id), 1, 0, rc=rc)
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+    value = farrayptr(1,scalar_id)
 
-    call MPI_BCAST(value, 1, MPI_REAL8, 0, mpicom, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u, mpierr=.true.)) return
 
   end subroutine shr_nuopc_methods_State_GetScalar
 
 !================================================================================
 
-  subroutine shr_nuopc_methods_State_SetScalar(value, scalar_id, State, mpicom, flds_scalar_name, flds_scalar_num,  rc)
+  subroutine shr_nuopc_methods_State_SetScalar(value, scalar_id, State, flds_scalar_name, flds_scalar_num,  rc)
     ! ----------------------------------------------
     ! Set scalar data from State for a particular name
     ! ----------------------------------------------
     use med_constants_mod , only : R8
     use ESMF              , only : ESMF_Field, ESMF_State, ESMF_StateGet, ESMF_FieldGet
-    use mpi               , only : MPI_COMM_RANK
-
+    use ESMF              , only : ESMF_VM, ESMF_VMGetCurrent, ESMF_VMGet
     real(R8),         intent(in)     :: value
     integer,          intent(in)     :: scalar_id
     type(ESMF_State), intent(inout)  :: State
-    integer,          intent(in)     :: mpicom
     character(len=*), intent(in)     :: flds_scalar_name
     integer,          intent(in)     :: flds_scalar_num
     integer,          intent(inout)  :: rc
@@ -3888,20 +3883,25 @@ module shr_nuopc_methods_mod
     ! local variables
     integer           :: mytask
     type(ESMF_Field)  :: field
+    type(ESMF_VM)     :: vm
     real(R8), pointer :: farrayptr(:,:)
     integer           :: dbrc
     character(len=*), parameter :: subname='(shr_nuopc_methods_State_SetScalar)'
 
     rc = ESMF_SUCCESS
 
-    call MPI_COMM_RANK(mpicom, mytask, rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u, mpierr=.true.)) return
+    call ESMF_VMGetCurrent(vm, rc=rc)
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_VMGet(vm, localPet=mytask, rc=rc)
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call ESMF_StateGet(State, itemName=trim(flds_scalar_name), field=field, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (mytask == 0) then
       call ESMF_FieldGet(field, farrayPtr = farrayptr, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
       if (scalar_id < 0 .or. scalar_id > flds_scalar_num) then
         call ESMF_LogWrite(trim(subname)//": ERROR in scalar_id", ESMF_LOGMSG_INFO, line=__LINE__, file=u_FILE_u, rc=dbrc)
         rc = ESMF_FAILURE
@@ -3931,11 +3931,11 @@ module shr_nuopc_methods_mod
     rc = ESMF_SUCCESS
 
     call NUOPC_GetStateMemberLists(state, fieldList=fieldList, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do i=1, size(fieldList)
       call shr_nuopc_methods_Field_UpdateTimestamp(fieldList(i), time, rc=rc)
-      if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
 
   end subroutine shr_nuopc_methods_State_UpdateTimestamp
@@ -3958,12 +3958,12 @@ module shr_nuopc_methods_mod
 
     call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, ms=ms, us=us, &
       ns=ns, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_AttributeSet(field, &
       name="TimeStamp", valueList=(/yy,mm,dd,h,m,s,ms,us,ns/), &
       convention="NUOPC", purpose="Instance", &
       attnestflag=ESMF_ATTNEST_ON, rc=rc)
-    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine shr_nuopc_methods_Field_UpdateTimestamp
 

--- a/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
@@ -786,10 +786,10 @@ module shr_nuopc_methods_mod
     do n = 1, fieldCount
       call ESMF_FieldBundleGet(FB, fieldName=lfieldnamelist(n), field=field, rc=rc)
       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_FieldDestroy(field, rc=rc)
+      call ESMF_FieldDestroy(field, rc=rc, noGarbage=.true.)
       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
-    call ESMF_FieldBundleDestroy(FB, rc=rc)
+    call ESMF_FieldBundleDestroy(FB, rc=rc, noGarbage=.true.)
     if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     deallocate(lfieldnamelist)
 

--- a/src/drivers/nuopc/shr/shr_nuopc_time_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_time_mod.F90
@@ -66,7 +66,6 @@ contains
     use med_constants_mod     , only : CL, CS
     use shr_file_mod          , only : shr_file_getUnit, shr_file_freeUnit
     use shr_cal_mod           , only : shr_cal_noleap, shr_cal_gregorian, shr_cal_calendarname
-    use shr_mpi_mod           , only : shr_mpi_bcast
 
     ! input/output variables
     type(ESMF_GridComp)  :: ensemble_driver, esmdriver
@@ -120,7 +119,6 @@ contains
     character(CL)           :: tmpstr              ! temporary
     character(CS)           :: calendar_name       ! Calendar name
     character(CS)           :: inst_suffix
-    integer                 :: mpicom              ! MPI communicator
     integer                 :: tmp(6)              ! Array for Broadcast
     integer                 :: dbrc
     logical                 :: isPresent


### PR DESCRIPTION
remove most uses of mpicom from nuopc code and use ESMF provided functions instead.  
   
Test suite:  create_test --xml-testlist ./testlist_cmeps.xml --xml-machine cheyenne --xml-category prealpha --walltime 00:30:00 --compare nov28 --baseline-root /glade/scratch/dunlap/BASELINES 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 

Components:
cam: 90274
cice: 8a26319
clm: 69bc1f1
mom_interface: 7ff64a
MOM6: 4a5a5d8
mosart: d8210dd
