### PR TITLE
med_map_RegridNorm refactor

### DIFF
--- a/scripts/testlist_cmeps.xml
+++ b/scripts/testlist_cmeps.xml
@@ -12,8 +12,8 @@
   </test>
   <test compset="ADWAV" grid="ww3a" name="SMS_Vmct_Ld2">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -31,8 +31,8 @@
   </test>
   <test compset="A1850DLND" grid="f09_f09_mg17" name="SMS_Vmct_Ld3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -50,8 +50,8 @@
   </test>
   <test compset="BMOM" grid="f19_g16" name="SMS_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -70,8 +70,8 @@
 
   <test compset="CMOM" grid="T62_g16" name="SMS_Vmct_Ld5" testmods="mom/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -90,8 +90,8 @@
 
   <test compset="GMOM" grid="T62_g16" name="SMS_Vmct_Ld5" testmods="mom/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -110,8 +110,8 @@
 
   <test compset="DTEST" grid="T62_g37" name="SMS_Vmct_Ld5" testmods="cice/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -130,8 +130,8 @@
 
   <test compset="F2000Nuopc" grid="f19_g17" name="SMS_Vmct_Ln5" testmods="cam/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -150,8 +150,8 @@
 
   <test compset="X" grid="f19_g17" name="SMS_Vmct">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -168,10 +168,20 @@
     </options>
   </test>
 
-  <test compset="A" grid="f19_g17_rx1" name="SMS_Vmct_Ld1">
+  <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ln11_D">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
       <machine name="theia" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test compset="A" grid="f19_g17_rx1" name="SMS_Vmct_Ld1">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -190,8 +200,8 @@
 
   <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="SMS_Vmct_Ln5" testmods="clm/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -210,8 +220,8 @@
 
   <test compset="QPC4" grid="ne16_ne16_mg17" name="SMS_Vmct_Ln5" testmods="cam/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -230,8 +240,8 @@
 
   <test compset="BMOM" grid="f19_g16" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -250,8 +260,8 @@
 
   <test compset="CMOM" grid="T62_g16" name="ERS_Vmct_Ld5" testmods="mom/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -270,8 +280,8 @@
 
   <test compset="GMOM" grid="T62_g16" name="ERS_Vmct_Ld5" testmods="mom/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -290,8 +300,8 @@
 
   <test compset="DTEST" grid="T62_g37" name="ERS_Vmct_Ld5" testmods="cice/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -310,8 +320,8 @@
 
   <test compset="F2000Nuopc" grid="f19_g17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -330,8 +340,8 @@
 
   <test compset="X" grid="f19_g17" name="ERS_Vmct_Ln9">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -350,8 +360,8 @@
 
   <test compset="A" grid="f19_g17_rx1" name="ERS_Vmct_Ln9">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -370,8 +380,8 @@
 
   <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="ERS_Vmct_Ln5" testmods="clm/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -390,8 +400,8 @@
 
   <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="theia" compiler="intel" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/src/drivers/nuopc/mediator/med_map_mod.F90
+++ b/src/drivers/nuopc/mediator/med_map_mod.F90
@@ -652,7 +652,7 @@ contains
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
              ! regrid FBSrc to FBDst
-             ! Copy data_src to data_srctmp and multiply by fraction
+             ! Copy data_src to data_srctmp and multiply by fraction, regrid this then replace with original data_src
              data_srctmp = data_src
              data_src = data_src * data_frac
 
@@ -670,11 +670,12 @@ contains
                 endif
                 allocate(data_dsttmp(size(data_dst)))
              endif
+             ! Copy data_dst to tmp location, regrid fraction from source
              data_dsttmp = data_dst
              data_dst = czero
              call shr_nuopc_methods_FB_FieldRegrid(FBFrac, mapnorm, FBDst, trim(fldname), RouteHandles(mapindex), rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
+            
              do i= 1,size(data_dst)
                 if (data_dst(i) /= 0.0_R8) then
                    data_dst(i) = data_dsttmp(i)/data_dst(i)

--- a/src/drivers/nuopc/mediator/med_map_mod.F90
+++ b/src/drivers/nuopc/mediator/med_map_mod.F90
@@ -509,13 +509,12 @@ contains
     use ESMF                  , only: ESMF_LOGMSG_ERROR, ESMF_FAILURE
     use ESMF                  , only: ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleGet
     use ESMF                  , only: ESMF_RouteHandle, ESMF_RouteHandleIsCreated, ESMF_Field
+    use ESMF                  , only: ESMF_FieldSet, ESMF_FieldBundleAdd
     use esmFlds               , only: compname
     use shr_nuopc_scalars_mod , only: flds_scalar_name
     use shr_nuopc_fldList_mod , only: mapnames, mapfcopy
     use shr_nuopc_fldList_mod , only: shr_nuopc_fldList_entry_type
-    use shr_nuopc_methods_mod , only: shr_nuopc_methods_FB_Init
     use shr_nuopc_methods_mod , only: shr_nuopc_methods_FB_Reset
-    use shr_nuopc_methods_mod , only: shr_nuopc_methods_FB_Clean
     use shr_nuopc_methods_mod , only: shr_nuopc_methods_FB_GetFldPtr
     use shr_nuopc_methods_mod , only: shr_nuopc_methods_FB_FieldRegrid
     use shr_nuopc_methods_mod , only: shr_nuopc_methods_FB_FldChk
@@ -541,9 +540,10 @@ contains
 
     ! local variables
     integer                     :: i, n
-    type(ESMF_FieldBundle)      :: FBSrcTmp        ! temporary
-    type(ESMF_FieldBundle)      :: FBNormSrc       ! temporary
-    type(ESMF_FieldBundle)      :: FBNormDst       ! temporary
+!    type(ESMF_FieldBundle)      :: FBSrcTmp        ! temporary
+!    type(ESMF_FieldBundle)      :: FBNormSrc       ! temporary
+!    type(ESMF_FieldBundle)      :: FBNormDst       ! temporary
+    type(ESMF_Field)            :: tmpfield, srcfield, dstfield
     integer                     :: mapindex
     character(len=CS)  :: lstring
     character(len=CS)  :: mapnorm
@@ -556,6 +556,7 @@ contains
     real(R8), pointer :: data_dstnorm(:) ! temporary
     real(R8), pointer :: data_frac(:)    ! temporary
     real(R8), pointer :: data_norm(:)    ! temporary
+    logical           :: isPresent
     character(len=*), parameter :: subname='(module_MED_Map:med_map_Regrid_Norm)'
     integer :: dbrc
 
@@ -563,8 +564,11 @@ contains
     call t_startf('MED:'//subname)
     call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
     call shr_nuopc_memcheck(subname, 1, mastertask)
-
     !---------------------------------------
+    nullify(data_srctmp)
+    nullify(data_srcnorm)
+    nullify(data_dstnorm)
+
 
     if (present(string)) then
       lstring = trim(string)
@@ -634,47 +638,64 @@ contains
           call shr_nuopc_methods_FB_FieldRegrid(FBSrc, fldname, FBDst, fldname, RouteHandles(mapindex), rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        else
-
-          if (.not. ESMF_FieldBundleIsCreated(FBSrcTmp)) then
-             ! Create a new temporary field bundle, FBSrcTmp if needed
-             call shr_nuopc_methods_FB_init(FBSrcTmp, flds_scalar_name, FBgeom=FBSrc, &
-                  fieldNameList=(/'data_srctmp'/), name='data_srctmp', rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             ! Get pointer to source field data in FBSrcTmp
-             call shr_nuopc_methods_FB_GetFldPtr(FBSrcTmp, 'data_srctmp', data_srctmp, rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-          end if
           ! Get pointer to source field data in FBSrc
-          call shr_nuopc_methods_FB_GetFldPtr(FBSrc, fldname, data_src, rc=rc)
+          call shr_nuopc_methods_FB_GetFldPtr(FBSrc, fldname, data_src, field=srcfield, rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+          if (.not. associated(data_srctmp)) then
+             ! Check if RemapTMP field is defined and define it if not
+             call ESMF_FieldBundleGet(FBSrc, 'RemapTMP', isPresent=isPresent, rc=rc)
+             if (.not. isPresent) then
+                tmpfield = srcfield
+                call ESMF_FieldSet(tmpfield, name='RemapTMP', rc=rc)
+                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+                call ESMF_FieldBundleAdd(FBSrc, (/tmpfield/), rc=rc)
+                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+             endif
+             ! Get pointer to source field data in
+             call shr_nuopc_methods_FB_GetFldPtr(FBSrc, 'RemapTMP', data_srctmp, rc=rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
           if ( trim(mapnorm) /= 'unset' .and. trim(mapnorm) /= 'one' .and. trim(mapnorm) /= 'none') then
 
              !-------------------------------------------------
              ! fractional normalization
              !-------------------------------------------------
+             if (.not. associated(data_srcnorm)) then
+                call ESMF_FieldBundleGet(FBSrc, 'NormTMP', isPresent=isPresent, rc=rc)
+                if (.not. isPresent) then
+                   tmpfield = srcfield
+                   call ESMF_FieldSet(tmpfield, name='NormTMP', rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-             ! create a temporary field bundle that will contain normalization on the source grid
-             if (.not. ESMF_FieldBundleIsCreated(FBNormSrc)) then
-                call shr_nuopc_methods_FB_init(FBout=FBNormSrc, flds_scalar_name=flds_scalar_name, &
-                     FBgeom=FBSrc, fieldNameList=(/trim(mapnorm)/), name='normsrc', rc=rc)
-                if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
+                   call ESMF_FieldBundleAdd(FBSrc, (/tmpfield/), rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+                endif
+                ! Get pointer to source field data in
+                call shr_nuopc_methods_FB_GetFldPtr(FBSrc, 'NormTMP', data_srcnorm, rc=rc)
+                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
              endif
-             call shr_nuopc_methods_FB_reset(FBNormSrc, value=czero, rc=rc)
-             if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
+             data_srcnorm = czero
 
-             call shr_nuopc_methods_FB_GetFldPtr(FBNormSrc, trim(mapnorm), data_srcnorm, rc=rc)
+             call shr_nuopc_methods_FB_GetFldPtr(FBDst, trim(fldname), data_dst, field=dstfield, rc=rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-             ! create a temporary field bundle that will contain normalization on the destination grid
-             if (.not. ESMF_FieldBundleIsCreated(FBNormDst)) then
-                call shr_nuopc_methods_FB_init(FBout=FBNormDst, flds_scalar_name=flds_scalar_name, &
-                     FBgeom=FBDst, fieldNameList=(/trim(mapnorm)/), name='normdst', rc=rc)
-                if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
+             if (.not. associated(data_dstnorm)) then
+                call ESMF_FieldBundleGet(FBDst, 'NormTMP', isPresent=isPresent, rc=rc)
+                if (.not. isPresent) then
+                   tmpfield = dstfield
+                   call ESMF_FieldSet(tmpfield, name='NormTMP', rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
+                   call ESMF_FieldBundleAdd(FBDst, (/tmpfield/), rc=rc)
+                   if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+                endif
+
+                call shr_nuopc_methods_FB_GetFldPtr(FBDst, 'NormTMP', data_dstnorm, rc=rc)
+                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
              endif
-             call shr_nuopc_methods_FB_reset(FBNormDst, value=czero, rc=rc)
-             if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
+             data_dstnorm = czero
 
              ! get a pointer to the array of the normalization on the source grid - this must
              ! be the same size is as fraction on the source grid
@@ -714,19 +735,13 @@ contains
                 call ESMF_LogWrite(trim(subname)//trim(lstring)//": skip : fld="//trim(fldname), &
                      ESMF_LOGMSG_INFO, rc=dbrc)
              else
-                call shr_nuopc_methods_FB_FieldRegrid( FBSrcTmp, 'data_srctmp', FBDst, fldname, RouteHandles(mapindex), rc)
+                call shr_nuopc_methods_FB_FieldRegrid( FBSrc, 'RegridTMP', FBDst, fldname, RouteHandles(mapindex), rc)
                 if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
              end if
 
-             call shr_nuopc_methods_FB_FieldRegrid(FBNormSrc, mapnorm, FBNormDst, mapnorm, RouteHandles(mapindex), rc)
+             call shr_nuopc_methods_FB_FieldRegrid(FBSrc, 'NormTMP', FBDst, 'NormTMP', RouteHandles(mapindex), rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-             ! multiply interpolated field (FBDst) by reciprocal of fraction on destination grid (FBNormDst)
-             call shr_nuopc_methods_FB_GetFldPtr(FBNormDst, trim(mapnorm), data_dstnorm, rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             call shr_nuopc_methods_FB_GetFldPtr(FBDst, trim(fldname), data_dst, rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
              do i= 1,size(data_dst)
                 if (data_dstnorm(i) == 0.0_R8) then
@@ -773,20 +788,6 @@ contains
        end if
 
     end do  ! loop over fields
-
-    ! Clean up temporary field bundles
-    if (ESMF_FieldBundleIsCreated(FBSrcTmp)) then
-       call shr_nuopc_methods_FB_clean(FBSrcTmp, rc=rc)
-       if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-    end if
-    if (ESMF_FieldBundleIsCreated(FBNormSrc)) then
-       call shr_nuopc_methods_FB_clean(FBNormSrc, rc=rc)
-       if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-    end if
-    if (ESMF_FieldBundleIsCreated(FBNormDst)) then
-       call shr_nuopc_methods_FB_clean(FBNormDst, rc=rc)
-       if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-    end if
     call t_stopf('MED:'//subname)
 
   end subroutine med_map_FB_Regrid_Norm

--- a/src/drivers/nuopc/mediator/med_map_mod.F90
+++ b/src/drivers/nuopc/mediator/med_map_mod.F90
@@ -541,14 +541,12 @@ contains
 
     ! local variables
     integer                     :: i, n
-    type(ESMF_FieldBundle)      :: FBNormDst       ! temporary
     type(ESMF_Field)            :: srcField
     type(ESMF_Field)            :: tmpfield
     integer                     :: mapindex
     character(len=CS)  :: lstring
     character(len=CS)  :: mapnorm
     character(len=CS)  :: fldname
-    character(len=CS)  :: csize1, csize2
     real(R8), allocatable :: data_srctmp(:)  ! temporary
     real(R8), allocatable :: data_dsttmp(:)  ! temporary
     real(R8), pointer     :: data_src(:)
@@ -624,15 +622,14 @@ contains
           CYCLE
        end if
 
-       ! Determine the normalization for the map
-       mapnorm  = fldsSrc(n)%mapnorm(destcomp)
-
        ! Do the mapping
        if (mapindex == mapfcopy) then
 
           call shr_nuopc_methods_FB_FieldRegrid(FBSrc, fldname, FBDst, fldname, RouteHandles(mapindex), rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        else
+          ! Determine the normalization for the map
+          mapnorm  = fldsSrc(n)%mapnorm(destcomp)
           if ( trim(mapnorm) /= 'unset' .and. trim(mapnorm) /= 'one' .and. trim(mapnorm) /= 'none') then
              ! Get field and pointer to source field data in FBSrc
              call shr_nuopc_methods_FB_GetFldPtr(FBSrc, fldname, data_src, field=srcfield, rc=rc)

--- a/src/drivers/nuopc/mediator/med_map_mod.F90
+++ b/src/drivers/nuopc/mediator/med_map_mod.F90
@@ -541,21 +541,20 @@ contains
 
     ! local variables
     integer                     :: i, n
-    type(ESMF_FieldBundle)      :: FBSrcTmp        ! temporary
-    type(ESMF_FieldBundle)      :: FBNormSrc       ! temporary
     type(ESMF_FieldBundle)      :: FBNormDst       ! temporary
+    type(ESMF_Field)            :: srcField
+    type(ESMF_Field)            :: tmpfield
     integer                     :: mapindex
     character(len=CS)  :: lstring
     character(len=CS)  :: mapnorm
     character(len=CS)  :: fldname
     character(len=CS)  :: csize1, csize2
-    real(R8), pointer :: data_srctmp(:)  ! temporary
-    real(R8), pointer :: data_src(:)     ! temporary
-    real(R8), pointer :: data_dst(:)     ! temporary
-    real(R8), pointer :: data_srcnorm(:) ! temporary
-    real(R8), pointer :: data_dstnorm(:) ! temporary
-    real(R8), pointer :: data_frac(:)    ! temporary
-    real(R8), pointer :: data_norm(:)    ! temporary
+    real(R8), allocatable :: data_srctmp(:)  ! temporary
+    real(R8), allocatable :: data_dsttmp(:)  ! temporary
+    real(R8), pointer     :: data_src(:)
+    real(R8), pointer     :: data_dst(:)
+    real(R8), pointer     :: data_frac(:)
+    real(R8), pointer     :: data_norm(:)
     character(len=*), parameter :: subname='(module_MED_Map:med_map_Regrid_Norm)'
     integer :: dbrc
 
@@ -588,7 +587,7 @@ contains
 
     call ESMF_LogWrite(trim(subname)//" *** mapping from "//trim(compname(srccomp))//" to "//&
          trim(compname(destcomp))//" ***", ESMF_LOGMSG_INFO, rc=dbrc)
-    nullify(data_srctmp)
+
     do n = 1,size(fldsSrc)
        ! Determine if field is a scalar - and if so go to next iternation
        fldname  = fldsSrc(n)%shortname
@@ -634,110 +633,54 @@ contains
           call shr_nuopc_methods_FB_FieldRegrid(FBSrc, fldname, FBDst, fldname, RouteHandles(mapindex), rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        else
-!          if (.not. associated(data_srctmp)) then
-!             allocate(data_srctmp(size(data_src))
-!          endif
           if ( trim(mapnorm) /= 'unset' .and. trim(mapnorm) /= 'one' .and. trim(mapnorm) /= 'none') then
-             ! Get pointer to source field data in FBSrc
-             call shr_nuopc_methods_FB_GetFldPtr(FBSrc, fldname, data_src, rc=rc)
+             ! Get field and pointer to source field data in FBSrc
+             call shr_nuopc_methods_FB_GetFldPtr(FBSrc, fldname, data_src, field=srcfield, rc=rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-
-             if (.not. ESMF_FieldBundleIsCreated(FBSrcTmp)) then
-                ! Create a new temporary field bundle, FBSrcTmp if needed
-                call shr_nuopc_methods_FB_init(FBSrcTmp, flds_scalar_name, FBgeom=FBSrc, &
-                     fieldNameList=(/'data_srctmp'/), name='data_srctmp', rc=rc)
-                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-                ! Get pointer to source field data in FBSrcTmp
-                call shr_nuopc_methods_FB_GetFldPtr(FBSrcTmp, 'data_srctmp', data_srctmp, rc=rc)
-                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-             end if
-
+             if (.not. allocated(data_srctmp) .or. size(data_srctmp) /= size(data_src)) then
+                if(allocated(data_srctmp)) then
+                   deallocate(data_srctmp)
+                endif
+                allocate(data_srctmp(size(data_src)))
+             endif
 
              !-------------------------------------------------
              ! fractional normalization
              !-------------------------------------------------
-             if(mastertask) print *,__FILE__,__LINE__
-
-             ! create a temporary field bundle that will contain normalization on the source grid
-             if (.not. ESMF_FieldBundleIsCreated(FBNormSrc)) then
-                call shr_nuopc_methods_FB_init(FBout=FBNormSrc, flds_scalar_name=flds_scalar_name, &
-                     FBgeom=FBSrc, fieldNameList=(/trim(mapnorm)/), name='normsrc', rc=rc)
-                if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-             endif
-             call shr_nuopc_methods_FB_reset(FBNormSrc, value=czero, rc=rc)
-             if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-
-             call shr_nuopc_methods_FB_GetFldPtr(FBNormSrc, trim(mapnorm), data_srcnorm, rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             ! create a temporary field bundle that will contain normalization on the destination grid
-             if (.not. ESMF_FieldBundleIsCreated(FBNormDst)) then
-                call shr_nuopc_methods_FB_init(FBout=FBNormDst, flds_scalar_name=flds_scalar_name, &
-                     FBgeom=FBDst, fieldNameList=(/trim(mapnorm)/), name='normdst', rc=rc)
-                if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-             endif
-             call shr_nuopc_methods_FB_reset(FBNormDst, value=czero, rc=rc)
-             if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
 
              ! get a pointer to the array of the normalization on the source grid - this must
              ! be the same size is as fraction on the source grid
              call shr_nuopc_methods_FB_GetFldPtr(FBFrac, trim(mapnorm), data_frac, rc=rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-             ! error checks
-             if (size(data_srcnorm) /= size(data_frac)) then
-                call ESMF_LogWrite(trim(subname)//" fldname= "//trim(fldname)//" mapnorm= "//trim(mapnorm), &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-                write(csize1,'(i8)') size(data_srcnorm)
-                write(csize2,'(i8)') size(data_frac)
-                call ESMF_LogWrite(trim(subname)//": ERROR data_normsrc size "//trim(csize1)//&
-                     " and data_frac size "//trim(csize2)//" are inconsistent", &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-                rc = ESMF_FAILURE
-                return
-             else if (size(data_srcnorm) /= size(data_srctmp)) then
-                write(csize1,'(i8)') size(data_srcnorm)
-                write(csize2,'(i8)') size(data_srctmp)
-                call ESMF_LogWrite(trim(subname)//": ERROR data_srcnorm size "//trim(csize1)//&
-                     " and data_srctmp size "//trim(csize2)//" are inconsistent", &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-                rc = ESMF_FAILURE
-                return
-             end if
+             ! regrid FBSrc to FBDst
+             ! Copy data_src to data_srctmp and multiply by fraction
+             data_srctmp = data_src
+             data_src = data_src * data_frac
 
-             ! now fill in the values for data_srcnorm and data_srctmp - these are the two arrays needed for normalization
-             ! Note that FBsrcTmp will now have the data_srctmp value
-             do i = 1,size(data_frac)
-                data_srcnorm(i) = data_frac(i)
-                data_srctmp(i)  = data_src(i) * data_frac(i)  ! Multiply initial field by data_frac
-             end do
-
-             ! regrid FBSrcTmp to FBDst
-             if (trim(fldname) == trim(flds_scalar_name)) then
-                call ESMF_LogWrite(trim(subname)//trim(lstring)//": skip : fld="//trim(fldname), &
-                     ESMF_LOGMSG_INFO, rc=dbrc)
-             else
-                call shr_nuopc_methods_FB_FieldRegrid( FBSrcTmp, 'data_srctmp', FBDst, fldname, RouteHandles(mapindex), rc)
-                if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-             end if
-
-             call shr_nuopc_methods_FB_FieldRegrid(FBNormSrc, mapnorm, FBNormDst, mapnorm, RouteHandles(mapindex), rc)
+             call shr_nuopc_methods_FB_FieldRegrid( FBSrc, trim(fldname), FBDst, fldname, RouteHandles(mapindex), rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             ! multiply interpolated field (FBDst) by reciprocal of fraction on destination grid (FBNormDst)
-             call shr_nuopc_methods_FB_GetFldPtr(FBNormDst, trim(mapnorm), data_dstnorm, rc=rc)
-             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+             ! Restore original value
+             data_src = data_srctmp
 
              call shr_nuopc_methods_FB_GetFldPtr(FBDst, trim(fldname), data_dst, rc=rc)
              if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
+             if (.not. allocated(data_dsttmp) .or. size(data_dsttmp) /= size(data_dst)) then
+                if(allocated(data_dsttmp)) then
+                   deallocate(data_dsttmp)
+                endif
+                allocate(data_dsttmp(size(data_dst)))
+             endif
+             data_dsttmp = data_dst
+             data_dst = czero
+             call shr_nuopc_methods_FB_FieldRegrid(FBFrac, mapnorm, FBDst, trim(fldname), RouteHandles(mapindex), rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+
              do i= 1,size(data_dst)
-                if (data_dstnorm(i) == 0.0_R8) then
-                   data_dst(i) = 0.0_R8
-                else
-                   data_dst(i) = data_dst(i)/data_dstnorm(i)
+                if (data_dst(i) /= 0.0_R8) then
+                   data_dst(i) = data_dsttmp(i)/data_dst(i)
                 endif
              end do
 
@@ -778,23 +721,13 @@ contains
        end if
 
     end do  ! loop over fields
-!    if (associated(data_srctmp)) then
-!       deallocate(data_srctmp)
-!    endif
+    if (allocated(data_srctmp)) then
+       deallocate(data_srctmp)
+    endif
+    if (allocated(data_dsttmp)) then
+       deallocate(data_dsttmp)
+    endif
 
-    ! Clean up temporary field bundles
-    if (ESMF_FieldBundleIsCreated(FBSrcTmp)) then
-       call shr_nuopc_methods_FB_clean(FBSrcTmp, rc=rc)
-       if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-    end if
-    if (ESMF_FieldBundleIsCreated(FBNormSrc)) then
-       call shr_nuopc_methods_FB_clean(FBNormSrc, rc=rc)
-       if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-    end if
-    if (ESMF_FieldBundleIsCreated(FBNormDst)) then
-       call shr_nuopc_methods_FB_clean(FBNormDst, rc=rc)
-       if (shr_nuopc_methods_chkerr(rc,__line__,u_file_u)) return
-    end if
     call t_stopf('MED:'//subname)
 
   end subroutine med_map_FB_Regrid_Norm

--- a/src/drivers/nuopc/mediator/med_phases_profile_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_profile_mod.F90
@@ -49,7 +49,7 @@ contains
     integer :: yr, mon, day, hr, min, sec
     integer :: iam
     logical :: ispresent
-    logical :: alarmison, stopalarmison=.false.
+    logical :: alarmison=.false., stopalarmison=.false.
     real(R8) :: current_time, wallclockelapsed, ypd
     real(r8) :: msize, mrss, ringdays
     integer, save :: iterations=0

--- a/src/drivers/nuopc/mediator/med_phases_profile_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_profile_mod.F90
@@ -49,7 +49,7 @@ contains
     integer :: yr, mon, day, hr, min, sec
     integer :: iam
     logical :: ispresent
-    logical :: alarmison, stopalarmison
+    logical :: alarmison, stopalarmison=.false.
     real(R8) :: current_time, wallclockelapsed, ypd
     real(r8) :: msize, mrss, ringdays
     integer, save :: iterations=0

--- a/src/drivers/nuopc/shr/med_constants_mod.F90
+++ b/src/drivers/nuopc/shr/med_constants_mod.F90
@@ -36,6 +36,6 @@ module med_constants_mod
   integer,  parameter :: med_constants_SecPerDay = 86400    ! Seconds per day
 
   !-----------------------------------------------------------------------------
-  integer :: med_constants_dbug_flag = 5
+  integer :: med_constants_dbug_flag = 0
 
 end module med_constants_mod

--- a/src/drivers/nuopc/shr/med_constants_mod.F90
+++ b/src/drivers/nuopc/shr/med_constants_mod.F90
@@ -36,6 +36,6 @@ module med_constants_mod
   integer,  parameter :: med_constants_SecPerDay = 86400    ! Seconds per day
 
   !-----------------------------------------------------------------------------
-  integer :: med_constants_dbug_flag = 0
+  integer :: med_constants_dbug_flag = 5
 
 end module med_constants_mod

--- a/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
@@ -1118,7 +1118,7 @@ module shr_nuopc_methods_mod
     use med_constants_mod, only : R8
     use perf_mod, only : t_startf, t_stopf
 
-    type(ESMF_FieldBundle), intent(inout) :: FBin
+    type(ESMF_FieldBundle), intent(in) :: FBin
     character(len=*)      , intent(in)    :: fldin
     type(ESMF_FieldBundle), intent(inout) :: FBout
     character(len=*)      , intent(in)    :: fldout

--- a/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_methods_mod.F90
@@ -1145,23 +1145,13 @@ module shr_nuopc_methods_mod
     if (shr_nuopc_methods_FB_FldChk(FBin , trim(fldin) , rc=rc) .and. &
         shr_nuopc_methods_FB_FldChk(FBout, trim(fldout), rc=rc)) then
 
-       call t_startf(subname//'1')
-
       call shr_nuopc_methods_FB_getFieldByName(FBin, trim(fldin), field1, rc=rc)
       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call t_stopf(subname//'1')
-
-      call t_startf(subname//'2')
-
       call shr_nuopc_methods_FB_getFieldByName(FBout, trim(fldout), field2, rc=rc)
       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call t_stopf(subname//'2')
-
-      call t_startf(subname//'3')
       call ESMF_FieldRegrid(field1, field2, routehandle=RH, &
         termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, rc=rc)
       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
-      call t_stopf(subname//'3')
    else
       if (dbug_flag > 1) then
         call ESMF_LogWrite(trim(subname)//" field not found: "//trim(fldin)//","//trim(fldout), ESMF_LOGMSG_INFO, rc=dbrc)

--- a/src/share/timing/GPTLprint_memusage.c
+++ b/src/share/timing/GPTLprint_memusage.c
@@ -84,7 +84,7 @@ int GPTLprint_memusage (const char *str)
   }
 
   if (bytesperblock > 0)
-    printf ("%s size=%.1f MB rss=%.1f MB share=%.1f MB text=%.1f MB datastack=%.1f MB\n",
+    printf ("%s size=%.1f MB rss=%.4f MB share=%.1f MB text=%.1f MB datastack=%.1f MB\n",
 	    str, size*blockstomb, rss*blockstomb, share*blockstomb,
 	    text*blockstomb, datastack*blockstomb);
   else


### PR DESCRIPTION
Optimize med_map_FB_RegridNorm function.  Fixes a memleak.  Improves performance.
Remove mct tests from default test list.  Add a debug A test.  Fix some issues with DEBUG runs. 

Test suite: ./create_test --xml-testlist ./testlist_cmeps.xml --xml-machine cheyenne --xml-category prealpha --walltime 00:30:00 --compare dec3 --baseline-root /glade/scratch/dunlap/BASELINES
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
