### PR TITLE
need to USE_FMS to build mom

### DIFF
--- a/src/drivers/mct/cime_config/buildexe
+++ b/src/drivers/mct/cime_config/buildexe
@@ -31,7 +31,12 @@ def _main_func():
         gmake     = case.get_value("GMAKE")
         gmake_j   = case.get_value("GMAKE_J")
         num_esp   = case.get_value("NUM_COMP_INST_ESP")
+        ocn_model = case.get_value("COMP_OCN")
+        atm_model = case.get_value("COMP_ATM")
         gmake_opts = get_standard_makefile_args(case)
+
+    if ocn_model == 'mom' or atm_model == "fv3gfs":
+        gmake_opts += "USE_FMS=TRUE"
 
 
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")


### PR DESCRIPTION
Fixes the build of MOM ocean model (along with an update in MOM_interface) 

Test suite: by hand SMS_Vmct_Ld5.T62_g16.CMOM.cheyenne_intel.mom-nuopc_cap
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
