### PR TITLE
use single branch for both CESM and FV3 applications

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1016,6 +1016,13 @@
       <mask>tx0.25v1</mask>
     </model_grid>
 
+    <model_grid alias="C384_t025" not_compset="_POP" >
+      <grid name="atm">C384</grid>
+      <grid name="lnd">C384</grid>
+      <grid name="ocnice">tx0.25v1</grid>
+      <mask>tx0.25v1</mask>
+    </model_grid>
+
     <!-- The following grid is only used for ADWAV testing -->
     <model_grid alias="ww3a" compset="_WW3|DWAV">
       <grid name="wav">ww3a</grid>
@@ -1037,7 +1044,6 @@
     </domain>
 
     <!-- LND domains for single column or regional -->
-
 
     <domain name="01col">
       <nx>1</nx> <ny>1</ny>
@@ -1547,6 +1553,13 @@
       <file grid="ocnice"  mask="tx0.66v1">$DIN_LOC_ROOT/share/domains/domain.ocn.C96_tx0.66v1.181210.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C96_181018_ESMFmesh.nc</mesh>
       <desc>C96 is a fvcubed xx-deg grid:</desc>
+      <support>Experimental for fv3 dycore</support>
+    </domain>
+
+    <domain name="C384">
+      <!-- The following nx is incorrect -->
+      <nx>100000</nx> <ny>1</ny>
+      <desc>C384 is a fvcubed xx-deg grid:</desc>
       <support>Experimental for fv3 dycore</support>
     </domain>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2419,7 +2419,8 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">netcdf/4.3.0</command>
         <command name="load">pnetcdf</command>
         <command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
-        <command name="load">esmf/8.0.0bs28g</command>
+	<command name="load">yaml-cpp</command>
+        <command name="load">esmf/8.0.0bs29g</command>
       </modules>
     </module_system>
     <environment_variables comp_interface="nuopc">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2300,18 +2300,20 @@ This allows using a different mpirun command to launch unit tests
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>
      </environment_variables>
+    <!--
     <environment_variables comp_interface="nuopc" mpilib="mvapich2">
       <env name="ESMFMKFILE">/work/02503/edwardsj/stampede2/esmf_8.0.0bs27/lib/libg/Linux.intel.64.mvapich2.default/esmf.mk</env>
      </environment_variables>
+    -->
     <environment_variables comp_interface="nuopc" mpilib="impi">
-      <!-- <env name="ESMFMKFILE">/work/02503/edwardsj/stampede2/esmf_8.0.0bs27/lib/libg/Linux.intel.64.intelmpi.default/esmf.mk</env> -->
-      <env name="ESMFMKFILE">/work/06242/tg855414/stampede2/ESMF-INSTALL/8.0.0bs28/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
-     </environment_variables>
+      <env name="ESMFMKFILE">/work/06242/tg855414/stampede2/ESMF-INSTALL/8.0.0bs29/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
+    </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
-      <!-- <env name="UGCSINPUTPATH">/work/02503/edwardsj/stampede2/FV3GFS/benchmark-20181016/</env> -->
-      <env name="UGCSINPUTPATH">/work/06242/tg855414/stampede2/FV3GFS/benchmark-20181016</env>
+      <env name="UGCSINPUTPATH">/work/06242/tg855414/stampede2/FV3GFS/benchmark-inputs/2012040100/gfs/fcst</env>
+      <env name="UGCSFIXEDFILEPATH">/work/06242/tg855414/stampede2/FV3GFS/fix_am</env>
+      <env name="UGCSADDONPATH">/work/06242/tg855414/stampede2/FV3GFS/addon</env>
     </environment_variables>
   </machine>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2423,8 +2423,10 @@ This allows using a different mpirun command to launch unit tests
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
-      <env name="UGCSINPUTPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/benchmark-20181016</env>
-    </environment_variables>
+      <env name="UGCSINPUTPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/benchmark-inputs/2012040100/gfs/fcst</env>
+      <env name="UGCSFIXEDFILEPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/fix_am</env>
+      <env name="UGCSADDONPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/addon</env>
+    </environment_variables>   
   </machine>
 
   <machine MACH="theta">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -312,7 +312,6 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<!-- for mpt/2.19 the -p needs to preceed -np -->
 	<arg name="labelstdout">-p "%g:"</arg>
 	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
 	<!-- the omplace argument needs to be last -->
@@ -386,13 +385,6 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">netcdf-mpi/4.6.1</command>
 	<command name="load">pnetcdf/1.11.0</command>
       </modules>
-<!--      <modules mpilib="mpt" compiler="intel" PIO_VERSION="2">
-	<command name="load">pio/2.4.1</command>
-      </modules>
-      <modules mpilib="mpt" compiler="intel" PIO_VERSION="1">
-	<command name="load">pio/1.10.1</command>
-      </modules>
--->
       <modules mpilib="mpt" compiler="pgi">
 	<command name="load">mpt/2.19</command>
 	<command name="load">netcdf-mpi/4.6.1</command>
@@ -426,7 +418,9 @@ This allows using a different mpirun command to launch unit tests
       <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/intel19/8.0.0bs32/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
-      <env name="UGCSINPUTPATH">/glade/work/dunlap/FV3GFS/benchmark-20181016/</env>
+      <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012040100/gfs/fcst</env>
+      <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/fix_am</env>
+      <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/addon</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -418,9 +418,9 @@ This allows using a different mpirun command to launch unit tests
       <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/intel19/8.0.0bs32/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
-      <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012040100/gfs/fcst</env>
-      <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/fix_am</env>
-      <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/addon</env>
+      <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012010100/gfs/fcst</env>
+      <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/fix_am</env>
+      <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/addon</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -25,6 +25,13 @@
     </values>
   </entry>
 
+  <entry id="PIO_VERSION">
+    <values>
+      <value mach="stampede2-skx">1</value>
+    </values>
+  </entry>
+
+
   <!--- uncomment and fill in relevant sections
   <entry id="PIO_ROOT">
     <values>

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -35,12 +35,14 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
         expect(os.path.isdir(rundir),
                "CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
         # only checks for the first instance in a multidriver case
-        if case.get_value("MULTI_DRIVER"):
+        if case.get_value("COMP_INTERFACE") == "nuopc":
+            rpointer = "rpointer.med"
+        elif case.get_value("MULTI_DRIVER"):
             rpointer = "rpointer.drv_0001"
         else:
             rpointer = "rpointer.drv"
         expect(os.path.exists(os.path.join(rundir,rpointer)),
-               "CONTINUE_RUN is true but this case does not appear to have restart files staged in {}".format(rundir))
+               "CONTINUE_RUN is true but this case does not appear to have restart files staged in {} {}".format(rundir,rpointer))
         # Finally we open the rpointer file and check that it's correct
         casename = case.get_value("CASE")
         with open(os.path.join(rundir,rpointer), "r") as fd:

--- a/src/drivers/nuopc/cime_config/buildnml
+++ b/src/drivers/nuopc/cime_config/buildnml
@@ -73,9 +73,9 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     nmlgen.init_defaults(infile, config)
 
     if case.get_value('MEDIATOR_READ_RESTART'):
-	nmlgen.set_value('mediator_read_restart', value='.true.')
+        nmlgen.set_value('mediator_read_restart', value='.true.')
     else:
-	nmlgen.set_value('mediator_read_restart', value='.false.')
+        nmlgen.set_value('mediator_read_restart', value='.false.')
 
     #--------------------------------
     # Overwrite: set brnch_retain_casename

--- a/src/drivers/nuopc/cime_config/buildnml
+++ b/src/drivers/nuopc/cime_config/buildnml
@@ -72,6 +72,11 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #----------------------------------------------------
     nmlgen.init_defaults(infile, config)
 
+    if case.get_value('MEDIATOR_READ_RESTART'):
+	nmlgen.set_value('mediator_read_restart', value='.true.')
+    else:
+	nmlgen.set_value('mediator_read_restart', value='.false.')
+
     #--------------------------------
     # Overwrite: set brnch_retain_casename
     #--------------------------------
@@ -363,7 +368,7 @@ def _create_runseq(case, coupling_times):
 
         elif (comp_atm == 'fv3gfs' and comp_ocn == "mom" and comp_ice == 'cice'):
             # for NEMS fully coupled
-            if case.get_value("CONTINUE_RUN"):
+            if case.get_value("CONTINUE_RUN") or case.get_value("MEDIATOR_READ_RESTART"):
                 logger.info("NUOPC run sequence: warm start (concurrent)")
                 runseq_input = os.path.join(input_dir, 'nuopc_runseq_NEMS.warm')
             else:

--- a/src/drivers/nuopc/cime_config/config_component.xml
+++ b/src/drivers/nuopc/cime_config/config_component.xml
@@ -465,6 +465,17 @@
     </desc>
   </entry>
 
+  <entry id="MEDIATOR_READ_RESTART">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_begin_stop_restart</group>
+    <file>env_run.xml</file>
+    <desc>
+      A setting of TRUE implies a continuation run for mediator only
+    </desc>
+  </entry>
+
   <entry id="RESUBMIT">
     <type>integer</type>
     <default_value>0</default_value>

--- a/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
@@ -587,6 +587,15 @@
     </values>
   </entry>
 
+  <entry id="mediator_read_restart" modify_via_xml="MEDIATOR_READ_RESTART">
+    <type>logical</type>
+    <category>expdef</category>
+    <group>DRIVER_attributes</group>
+    <desc>
+      only have the mediator reads the restart file regardless of start type
+    </desc>
+  </entry>
+
   <entry id="case_name" modify_via_xml="CASE">
     <type>char</type>
     <category>expdef</category>

--- a/src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml
@@ -352,7 +352,7 @@
       <machine name="theia" compiler="intel" category="nuopc"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20:00 </option>
+      <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
 

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -919,6 +919,7 @@ contains
     character(len=32), allocatable :: attrList(:)
     integer                        :: componentCount
     character(len=*), parameter    :: subname = "(esm.F90:AddAttributes)"
+    logical                        :: lvalue = .false.
     !-------------------------------------------
 
     rc = ESMF_Success

--- a/src/drivers/nuopc/mediator/med_merge_mod.F90
+++ b/src/drivers/nuopc/mediator/med_merge_mod.F90
@@ -580,7 +580,6 @@ contains
     integer                    :: lb1,ub1,lb2,ub2,i,j,n
     logical                    :: wgtfound, FBinfound
     integer                    :: dbrc
-    character(len=CL)          :: errorName
     character(len=*),parameter :: subname='(med_merge_field_2d)'
     ! ----------------------------------------------
 
@@ -631,9 +630,8 @@ contains
        if (.not. FB_FldChk(FBinE, trim(fnameE), rc=rc)) FBinfound = .false.
     endif
     if (.not. FBinfound) then
-       call ESMF_LogWrite(trim(subname)//": ERROR field not found in FBin, skipping merge "//trim(errorName), &
+       call ESMF_LogWrite(trim(subname)//": WARNING field not found in FBin, skipping merge "//trim(fnameout), &
             ESMF_LOGMSG_WARNING, line=__LINE__, file=u_FILE_u, rc=dbrc)
-       rc = ESMF_FAILURE
        return
     endif
 

--- a/src/drivers/nuopc/mediator/med_merge_mod.F90
+++ b/src/drivers/nuopc/mediator/med_merge_mod.F90
@@ -580,6 +580,7 @@ contains
     integer                    :: lb1,ub1,lb2,ub2,i,j,n
     logical                    :: wgtfound, FBinfound
     integer                    :: dbrc
+    character(len=CL)          :: errorName
     character(len=*),parameter :: subname='(med_merge_field_2d)'
     ! ----------------------------------------------
 
@@ -630,8 +631,9 @@ contains
        if (.not. FB_FldChk(FBinE, trim(fnameE), rc=rc)) FBinfound = .false.
     endif
     if (.not. FBinfound) then
-       call ESMF_LogWrite(trim(subname)//": WARNING field not found in FBin, skipping merge "//trim(fnameout), &
+       call ESMF_LogWrite(trim(subname)//": ERROR field not found in FBin, skipping merge "//trim(errorName), &
             ESMF_LOGMSG_WARNING, line=__LINE__, file=u_FILE_u, rc=dbrc)
+       rc = ESMF_FAILURE
        return
     endif
 

--- a/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
@@ -514,6 +514,7 @@ contains
           end do
 
           customwgt(:) = wgtm01(:) / const_lhvap
+          ! mean_evap_rate = mean_laten_heat_flux * (1-ice_fraction)/const_lhvap
           call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_evap', &
                FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_evap', wgtA=ocnwgt1, &
                FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lat' , wgtB=customwgt, rc=rc)

--- a/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
@@ -542,7 +542,6 @@ contains
                FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lwdn' , wgtB=ocnwgt1, &
                FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_lwnet' , wgtc=wgtp01, rc=rc)
 
-          ! Merge rain with melted ice before sending liquid precipitation to ocean
           call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_rain' , &
                FBInA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_rain' , wgtA=ofrac, &
                FBInB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_meltw', wgtB=ifrac, rc=rc)

--- a/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_prep_ocn_mod.F90
@@ -514,7 +514,6 @@ contains
           end do
 
           customwgt(:) = wgtm01(:) / const_lhvap
-          ! mean_evap_rate = mean_laten_heat_flux * (1-ice_fraction)/const_lhvap
           call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_evap', &
                FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_evap', wgtA=ocnwgt1, &
                FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lat' , wgtB=customwgt, rc=rc)


### PR DESCRIPTION
This changes aims to use single branch for both CESM and FV3 applications.

**Note about component hashes:**
UFSCOMP: Need to modify Externals.cfg for CICE to point single branch for both CESM and FV3 applications (branch = mvertens/nuopc_cap)
CIME: e57f162

**Test suite:** 
There is no specific test suite for FV3 but following commands can be used to check build and run 

./create_newcase --compset UFS_S2S --res C384_t025 --case ufs.s2s.c384_t025.jan --driver nuopc --run-unsupported
cd ufs.s2s.c384_t025.jan/
./case.setup
./xmlchange DOUT_S=FALSE
./xmlchange STOP_N=1
./xmlchange RUN_REFDATE=2012-01-01
./xmlchange RUN_STARTDATE=2012-01-01
./xmlchange JOB_WALLCLOCK_TIME=01:00:00
qcmd -- ./case.build
./case.submit

**To test CESM application:**

The following command can be used to test app_cesm-cmeps. **Tester will see FAIL in all NLCOMP phases due to the change in the namelist files such as ice namelist and change in the PET layouts of ice component because the ice branches are merged together to have single ice branch for FV3 and CESM applications.** It would be better to create new baseline.

qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml --xml-machine cheyenne --xml-category nuopc --compare apr23intel19 --baseline-root /glade/p/cesmdata/cseg/nuopc_baselines

Test baseline: N/A
Test namelist changes: N/A
Test status: N/A

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: