### PR TITLE
fv3 namelist

### DIFF
--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1206,15 +1206,10 @@ class Namelist(object):
                     lines[-1] += "\n"
                     for line in lines:
                         out_file.write(line)
-                if format_ == 'nml':
-                    out_file.write("/\n")
-                if format_ == 'nmlcontents':
-                    out_file.write("\n")
-            else:
-                if format_ == 'nml':
-                    out_file.write("/\n")
-                if format_ == 'nmlcontents':
-                    out_file.write("\n")
+            if format_ == 'nml':
+                out_file.write("/\n")
+            if format_ == 'nmlcontents':
+                out_file.write("\n")
 
     def _write_nuopc(self, out_file, groups, sorted_groups, skip_comps):
         """Unwrapped version of `write` assuming that a file object is input."""

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1178,36 +1178,43 @@ class Namelist(object):
         for group_name in group_names:
             if format_ == 'nml':
                 out_file.write("&{}\n".format(group_name))
-            group = self._groups[group_name]
-            for name in sorted(group.keys()):
-                values = group[name]
+            # allow empty group
+            if group_name in self._groups:
+                group = self._groups[group_name]
+                for name in sorted(group.keys()):
+                    values = group[name]
 
-                # @ is used in a namelist to put the same namelist variable in multiple groups
-                # in the write phase, all characters in the namelist variable name after
-                # the @ and including the @ should be removed
-                if "@" in name:
-                    name = re.sub('@.+$', "", name)
+                    # @ is used in a namelist to put the same namelist variable in multiple groups
+                    # in the write phase, all characters in the namelist variable name after
+                    # the @ and including the @ should be removed
+                    if "@" in name:
+                        name = re.sub('@.+$', "", name)
 
-                # To prettify things for long lists of values, build strings
-                # line-by-line.
-                if values[0] == "True" or values[0] == "False":
-                    values[0] = values[0].replace("True",".true.").replace("False",".false.")
-                lines = ["  {}{} {}".format(name, equals, values[0])]
-                for value in values[1:]:
-                    if value == "True" or value == "False":
-                        value = value.replace("True",".true.").replace("False",".false.")
-                    if len(lines[-1]) + len(value) <= 77:
-                        lines[-1] += ", " + value
-                    else:
-                        lines[-1] += ",\n"
-                        lines.append("      " + value)
-                lines[-1] += "\n"
-                for line in lines:
-                    out_file.write(line)
-            if format_ == 'nml':
-                out_file.write("/\n")
-            if format_ == 'nmlcontents':
-                out_file.write("\n")
+                    # To prettify things for long lists of values, build strings
+                    # line-by-line.
+                    if values[0] == "True" or values[0] == "False":
+                        values[0] = values[0].replace("True",".true.").replace("False",".false.")
+                    lines = ["  {}{} {}".format(name, equals, values[0])]
+                    for value in values[1:]:
+                        if value == "True" or value == "False":
+                            value = value.replace("True",".true.").replace("False",".false.")
+                        if len(lines[-1]) + len(value) <= 77:
+                            lines[-1] += ", " + value
+                        else:
+                            lines[-1] += ",\n"
+                            lines.append("      " + value)
+                    lines[-1] += "\n"
+                    for line in lines:
+                        out_file.write(line)
+                if format_ == 'nml':
+                    out_file.write("/\n")
+                if format_ == 'nmlcontents':
+                    out_file.write("\n")
+            else:
+                if format_ == 'nml':
+                    out_file.write("/\n")
+                if format_ == 'nmlcontents':
+                    out_file.write("\n")
 
     def _write_nuopc(self, out_file, groups, sorted_groups, skip_comps):
         """Unwrapped version of `write` assuming that a file object is input."""
@@ -1220,7 +1227,7 @@ class Namelist(object):
             group_names = groups
 
         for group_name in group_names:
-            if "_attributes" not in group_name and "nuopc_" not in group_name:
+            if "_attributes" not in group_name and "nuopc_" not in group_name and "_no_group" not in group_name:
                 continue
             if "_attributes" in group_name:
                 out_file.write("{}::\n".format(group_name))


### PR DESCRIPTION
These modifications allow to use empty namelist groups (for fv3gfs application) with CIME.

**Used hashes/branches:**
fv3gfs_interface: fv3namelist
cice: 472a2f2
mom interface: dev/nuopc_cmeps_fv3
cime: fv3namelist

**Test suite:** 
**To test FV3 application:**
./create_newcase --compset UFS_S2S --res C384_t025 --case ufs.s2s.c384_t025.jan --driver nuopc --run-unsupported
cd ufs.s2s.c384_t025.jan/
./case.setup
./xmlchange DOUT_S=FALSE
./xmlchange STOP_N=1
./xmlchange RUN_REFDATE=2012-01-01
./xmlchange RUN_STARTDATE=2012-01-01
./xmlchange JOB_WALLCLOCK_TIME=01:00:00
./xmlchange NTASKS_CPL=648
./xmlchange NTASKS_ATM=648
./xmlchange NTASKS_OCN=360
./xmlchange NTASKS_ICE=360
./xmlchange ROOTPE_CPL=0
./xmlchange ROOTPE_ATM=0
./xmlchange ROOTPE_OCN=648
./xmlchange ROOTPE_ICE=1008
and add following definition to user_nl_fv3gfs
write_tasks_per_group = 72
qcmd -- ./case.build
./case.submit

**To test CESM application:**
qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml --xml-machine cheyenne --xml-category nuopc --compare may10intel19 --baseline-root /glade/p/cesmdata/cseg/nuopc_baselines

**Test baseline:** may10intel19

**Test namelist changes:** model_configure and input.nml are generated automatically

**Test expected fails:**
Following tests fail due to the MOM restart problem: 
FAIL ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io COMPARE_base_rest
FAIL ERS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel COMPARE_base_rest

Following tests fail if you don't set PIO_REARRANGER as 1 (./xmlchange PIO_REARRANGER=1)
FAIL ERS_Vnuopc_Ln5.f19_f19_mg17.F2000Nuopc.cheyenne_intel.cam-nuopc_cap RUN
FAIL SMS_Vnuopc_Ln5.f19_f19_mg17.F2000Nuopc.cheyenne_intel.cam-nuopc_cap RUN

In the *cpl.r* file, only one field (atmImp_Sa_topo) is not bit2bit identical.

Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 